### PR TITLE
Feat/google login

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,8 @@ gem "devise-i18n-views"
 gem "rest-client"
 
 # Google OAuth2認証用のGem
-gem 'omniauth-google-oauth2'
-gem 'omniauth-rails_csrf_protection'
+gem "omniauth-google-oauth2"
+gem "omniauth-rails_csrf_protection"
 
 gem "rspotify"
 gem "dotenv-rails"
@@ -50,8 +50,8 @@ gem "redis"
 gem "sidekiq"
 gem "sidekiq-cron"
 gem "kaminari"
-gem 'omniauth-google-oauth2'
-gem 'omniauth-rails_csrf_protection'
+gem "omniauth-google-oauth2"
+gem "omniauth-rails_csrf_protection"
 
 gem "mini_magick"
 gem "image_processing", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,8 @@ gem "redis"
 gem "sidekiq"
 gem "sidekiq-cron"
 gem "kaminari"
+gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
 
 gem "mini_magick"
 gem "image_processing", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,10 @@ gem "devise-i18n"
 gem "devise-i18n-views"
 gem "rest-client"
 
+# Google OAuth2認証用のGem
+gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'
+
 gem "rspotify"
 gem "dotenv-rails"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,8 +231,16 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
+    omniauth-google-oauth2 (1.2.1)
+      jwt (>= 2.9.2)
+      oauth2 (~> 2.0)
+      omniauth (~> 2.0)
+      omniauth-oauth2 (~> 1.8)
     omniauth-oauth2 (1.8.0)
       oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
       omniauth (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.26.3)
@@ -426,6 +434,8 @@ DEPENDENCIES
   jsbundling-rails
   kaminari
   mini_magick
+  omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,23 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_before_action :verify_authenticity_token, only: :google_oauth2
+
+  def google_oauth2
+    callback_for(:google)
+  end
+
+  def callback_for(provider)
+    @user = User.from_omniauth(request.env['omniauth.auth'])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
+    else
+      session["devise.#{provider}_data"] = request.env['omniauth.auth'].except(:extra)
+      redirect_to new_user_registration_url
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -6,7 +6,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def callback_for(provider)
-    @user = User.from_omniauth(request.env['omniauth.auth'])
+    @user = User.from_omniauth(request.env["omniauth.auth"])
 
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentication

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -12,9 +12,14 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
     else
-      session["devise.#{provider}_data"] = request.env['omniauth.auth'].except(:extra)
+      Rails.logger.error "OAuth user creation failed: #{@user.errors.full_messages.join(', ')}"
+      flash[:alert] = "Google認証に失敗しました。#{@user.errors.full_messages.join(', ')}"
       redirect_to new_user_registration_url
     end
+  rescue => e
+    Rails.logger.error "OAuth error: #{e.message}"
+    flash[:alert] = "認証中にエラーが発生しました"
+    redirect_to new_user_registration_url
   end
 
   def failure

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_one :profile
   # Deviseのモジュール
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:google_oauth2]
+         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [ :google_oauth2 ]
   # バリデーション
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, uniqueness: true
@@ -40,10 +40,10 @@ class User < ApplicationRecord
   def self.from_omniauth(auth)
     # まず、OAuth認証情報で検索
     user = find_by(provider: auth.provider, uid: auth.uid)
-    
+
     # 見つからない場合、メールアドレスで検索
     user ||= find_by(email: auth.info.email)
-    
+
     if user
       # 既存ユーザーの場合、OAuth情報を更新
       user.update(
@@ -54,7 +54,7 @@ class User < ApplicationRecord
       # 新規ユーザーを作成
       user = new(
         email: auth.info.email,
-        name: auth.info.name || auth.info.email.split('@').first,
+        name: auth.info.name || auth.info.email.split("@").first,
         password: Devise.friendly_token[0, 20],
         provider: auth.provider,
         uid: auth.uid
@@ -64,7 +64,7 @@ class User < ApplicationRecord
     unless user.save
       Rails.logger.error "User save failed: #{user.errors.full_messages.join(', ')}"
     end
-    
+
     user
   end
   def self.create_unique_string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,12 @@ class User < ApplicationRecord
   has_one :profile
   # Deviseのモジュール
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:google_oauth2]
   # バリデーション
   validates :name, presence: true, length: { maximum: 50 }
+  validates :email, presence: true, uniqueness: true
+  validates :password, presence: true, length: { minimum: 6 }
+  validates :uid, uniqueness: { scope: :provider }, if: -> { uid.present? }
 
   # favorites の関連
   has_many :favorites, dependent: :destroy
@@ -32,5 +35,16 @@ class User < ApplicationRecord
 
   def following?(other_user)
     following.include?(other_user)
+  end
+
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.name = auth.info.name
+      user.password = Devise.friendly_token[0,20]
+    end
+  end
+  def self.create_unique_string
+    SecureRandom.uuid
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -55,7 +55,7 @@
               type="button"
               data-password-visibility-target="button"
               data-action="click->password-visibility#toggle"
-              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none">
+              class="absolute right-3 top-1/2 transform text-gray-500 hover:text-gray-700 focus:outline-none">
               👁
             </button>
           </div>
@@ -78,7 +78,7 @@
               type="button"
               data-password-visibility-target="button"
               data-action="click->password-visibility#toggle"
-              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none">
+              class="absolute right-3 top-1/2 transform text-gray-500 hover:text-gray-700 focus:outline-none">
               👁
             </button>
           </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="flex justify-center items-center bg-customblue">
   <div class="rounded-lg p-8" style="aspect-ratio: 1 / 1; width: 90%; max-width: 400px;">
     <%= render "devise/shared/form_layout" do %>
-      <form class="space-y-6 h-full" action="<%= registration_path(resource_name) %>" method="post" enctype="multipart/form-data">
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6 h-full" }) do |form| %>
         <!-- Title -->
         <h2 class="text-2xl font-bold text-gray-700 text-center mb-6">
           <%= t('devise.registrations.new.sign_up', default: 'アカウント登録') %>
@@ -13,31 +13,16 @@
         <% end %>
 
         <!-- Name Field -->
-        <div class="field">
+        <div class="mb-4">
           <label for="name" class="block text-gray-700 text-sm font-bold mb-2">
             <%= t('activerecord.attributes.user.name', default: '名前') %>
           </label>
-          <input 
-            id="name" 
-            name="user[name]" 
-            type="text" 
-            placeholder="<%= t('activerecord.attributes.user.name', default: '名前') %>" 
-            required 
-            autofocus 
-            class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400"
-            value="<%= resource.name if resource.present? %>">
-        </div>
-
-        <!-- Profile Image Field -->
-        <div class="field">
-          <label for="profile_image" class="block text-gray-700 text-sm font-bold mb-2">
-            <%= t('activerecord.attributes.user.profile_image', default: 'プロフィール画像') %>
-          </label>
-          <input 
-            id="profile_image" 
-            name="user[profile_image]" 
-            type="file" 
-            class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50">
+          <%= form.text_field :name,
+            id: "name",
+            placeholder: t('activerecord.attributes.user.name', default: '名前'),
+            required: true,
+            autofocus: true,
+            class: "shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400" %>
         </div>
 
         <!-- Email Field -->
@@ -45,15 +30,12 @@
           <label for="email" class="block text-gray-700 text-sm font-bold mb-2">
             <%= t('activerecord.attributes.user.email', default: 'Eメール') %>
           </label>
-          <input 
-            id="email" 
-            name="user[email]" 
-            type="email" 
-            placeholder="<%= t('activerecord.attributes.user.email', default: 'Eメール') %>" 
-            required 
-            autocomplete="email" 
-            class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400"
-            value="<%= resource.email if resource.present? %>">
+          <%= form.email_field :email,
+            id: "email",
+            placeholder: t('activerecord.attributes.user.email', default: 'Eメール'),
+            required: true,
+            autocomplete: "email",
+            class: "shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400" %>
         </div>
 
         <!-- Password Field -->
@@ -61,75 +43,76 @@
           <label for="password" class="block text-gray-700 text-sm font-bold mb-2">
             <%= t('activerecord.attributes.user.password', default: 'パスワード') %>
           </label>
-          <% if @minimum_password_length %>
-            <em class="text-gray-600 text-sm">
-              <%= t('devise.shared.minimum_password_length', count: @minimum_password_length, default: '（6文字以上）') %>
-            </em>
-          <% end %>
-          <div class="relative">
-            <input 
-              id="password" 
-              name="user[password]" 
-              type="password" 
-              placeholder="<%= t('activerecord.attributes.user.password', default: 'パスワード') %>" 
-              required 
-              autocomplete="new-password" 
-              class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400">
-            <button 
-              type="button" 
-              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none" 
-              onclick="togglePasswordVisibility('password', this)">
+          <div data-controller="password-visibility">
+            <%= form.password_field :password,
+              id: "password",
+              placeholder: t('activerecord.attributes.user.password', default: 'パスワード'),
+              required: true,
+              autocomplete: "new-password",
+              class: "shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400",
+              data: { password_visibility_target: "input" } %>
+            <button
+              type="button"
+              data-password-visibility-target="button"
+              data-action="click->password-visibility#toggle"
+              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none">
               👁
             </button>
           </div>
         </div>
 
         <!-- Password Confirmation Field -->
-        <div class="mb-6 relative">
+        <div class="mb-4 relative">
           <label for="password_confirmation" class="block text-gray-700 text-sm font-bold mb-2">
             <%= t('activerecord.attributes.user.password_confirmation', default: 'パスワード（確認用）') %>
           </label>
-          <div class="relative">
-            <input 
-              id="password_confirmation" 
-              name="user[password_confirmation]" 
-              type="password" 
-              placeholder="<%= t('activerecord.attributes.user.password_confirmation', default: 'パスワード（確認用）') %>" 
-              required 
-              autocomplete="new-password" 
-              class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400">
-            <button 
-              type="button" 
-              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none" 
-              onclick="togglePasswordVisibility('password_confirmation', this)">
+          <div data-controller="password-visibility">
+            <%= form.password_field :password_confirmation,
+              id: "password_confirmation",
+              placeholder: t('activerecord.attributes.user.password_confirmation', default: 'パスワード（確認用）'),
+              required: true,
+              autocomplete: "new-password",
+              class: "shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400",
+              data: { password_visibility_target: "input" } %>
+            <button
+              type="button"
+              data-password-visibility-target="button"
+              data-action="click->password-visibility#toggle"
+              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none">
               👁
             </button>
           </div>
         </div>
 
         <!-- Submit Button -->
-        <div class="flex items-center justify-between">
-          <button 
-            type="submit" 
-            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded focus:outline-none focus:shadow-outline w-full">
-            <%= t('devise.registrations.new.sign_up', default: 'アカウント登録') %>
-          </button>
+        <div class="mt-6">
+          <%= form.submit t('devise.registrations.new.sign_up', default: 'アカウント登録'),
+            class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
         </div>
-        <%= render "devise/shared/links" %>
-      </form>
+
+        <!-- Google Login -->
+        <div class="mt-6">
+          <%= link_to user_google_oauth2_omniauth_authorize_path,
+            method: :post,
+            data: { turbo: false },
+            class: "w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50" do %>
+            <img class="h-5 w-5" src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google logo">
+            <span class="ml-2">Googleで登録</span>
+          <% end %>
+        </div>
+
+        <!-- Links -->
+        <div class="mt-4 flex items-center justify-between">
+          <div class="text-sm">
+            <%= link_to t("devise.shared.links.sign_in", default: "ログイン"), new_session_path(resource_name), class: "font-medium text-indigo-600 hover:text-indigo-500" %>
+          </div>
+        </div>
+        <div class="mt-4 flex items-center justify-between">
+          <div class="text-sm">
+            <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(resource_name), class: "font-medium text-indigo-600 hover:text-indigo-500" %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>
-
-<script>
-  function togglePasswordVisibility(inputId, button) {
-    const input = document.getElementById(inputId);
-    if (input.type === "password") {
-      input.type = "text";
-      button.textContent = "🙈"; // Hide icon
-    } else {
-      input.type = "password";
-      button.textContent = "👁"; // Show icon
-    }
-  }
-</script>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="flex justify-center items-center bg-customblue">
   <div class="rounded-lg p-8" style="aspect-ratio: 1 / 1; width: 90%; max-width: 400px;">
     <%= render "devise/shared/form_layout" do %>
-      <form class="space-y-6 h-full" action="<%= session_path(resource_name) %>" method="post">
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6 h-full" }) do |form| %>
         <!-- Title -->
         <h2 class="text-2xl font-bold text-gray-700 text-center mb-6">
           <%= t('devise.sessions.new.sign_in', default: 'ログイン') %>
@@ -17,15 +17,12 @@
           <label for="email" class="block text-gray-700 text-sm font-bold mb-2">
             <%= t('activerecord.attributes.user.email', default: 'Eメール') %>
           </label>
-          <input 
-            id="email" 
-            name="user[email]" 
-            type="email" 
-            placeholder="<%= t('activerecord.attributes.user.email', default: 'Eメール') %>" 
-            required 
-            autocomplete="email" 
-            class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400"
-            value="<%= resource.email if resource.present? %>">
+          <%= form.email_field :email, 
+            id: "email", 
+            placeholder: t('activerecord.attributes.user.email', default: 'Eメール'), 
+            required: true, 
+            autocomplete: "email", 
+            class: "shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400" %>
         </div>
 
         <!-- Password Field -->
@@ -34,35 +31,46 @@
             <%= t('activerecord.attributes.user.password', default: 'パスワード') %>
           </label>
           <div data-controller="password-visibility">
-            <input 
-              id="password" 
-              name="user[password]" 
-              type="password" 
-              placeholder="<%= t('activerecord.attributes.user.password', default: 'パスワード') %>" 
-              required 
-              autocomplete="current-password" 
-              class="shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400"
-              data-password-visibility-target="input">
+            <%= form.password_field :password, 
+              id: "password", 
+              placeholder: t('activerecord.attributes.user.password', default: 'パスワード'), 
+              required: true, 
+              autocomplete: "current-password", 
+              class: "shadow appearance-none border rounded w-full py-3 px-4 text-gray-700 leading-tight focus:outline-none focus:ring-2 focus:ring-blue-500 focus:shadow-outline bg-gray-50 placeholder-gray-400",
+              data: { password_visibility_target: "input" } %>
             <button 
               type="button" 
               data-password-visibility-target="button"
               data-action="click->password-visibility#toggle"
-              class="absolute right-3 top-1/2 text-gray-500 hover:text-gray-700 focus:outline-none">
+              class="absolute right-3 top-1/2 transform  text-gray-500 hover:text-gray-700 focus:outline-none">
               👁
             </button>
           </div>
         </div>
 
         <!-- Submit Button -->
-        <div class="flex items-center justify-between">
-          <button 
-            type="submit" 
-            class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded focus:outline-none focus:shadow-outline w-full">
-            <%= t('devise.sessions.new.sign_in', default: 'ログイン') %>
-          </button>
+        <div class="mt-6">
+          <%= form.button type: 'submit', class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" do %>
+            <%= t("devise.sessions.new.sign_in", default: "ログイン") %>
+          <% end %>
         </div>
-        <%= render "devise/shared/links" %>
-      </form>
+        <div class="mt-6">
+        <%= link_to user_google_oauth2_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50" do %>
+          <img class="h-5 w-5" src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google logo">
+          <span class="ml-2">Googleでログイン</span>
+        <% end %>
+        <div class="mt-4 flex items-center justify-between">
+          <div class="text-sm">
+            <%= link_to t("devise.shared.links.sign_up", default: "アカウント登録"), new_user_registration_path, class: "font-medium text-indigo-600 hover:text-indigo-500" %>
+          </div>
+        </div>
+      </div>
+        <div class="mt-4 flex items-center justify-between">
+          <div class="text-sm">
+            <%= link_to t("devise.shared.links.forgot_your_password"), new_password_path(resource_name), class: "font-medium text-indigo-600 hover:text-indigo-500" %>
+          </div>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -47,7 +47,7 @@
               type="button" 
               data-password-visibility-target="button"
               data-action="click->password-visibility#toggle"
-              class="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none">
+              class="absolute right-3 top-1/2 text-gray-500 hover:text-gray-700 focus:outline-none">
               👁
             </button>
           </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -20,6 +20,11 @@
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to t('devise.shared.links.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider), default: "%{provider}でログイン"), omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to user_google_oauth2_omniauth_authorize_path, method: :post, class: "mt-4 inline-block w-full text-center bg-white text-gray-700 font-bold py-3 px-6 rounded border border-gray-300 hover:bg-gray-100 focus:outline-none focus:shadow-outline", data: { turbo: false } do %>
+      <div class="flex items-center justify-center">
+        <img src="https://www.google.com/favicon.ico" alt="Google" class="w-5 h-5 mr-2">
+        <span>Googleでログイン</span>
+      </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-
+  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,17 +272,17 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :google_oauth2, 
-                  ENV["GOOGLE_CLIENT_ID"], 
+  config.omniauth :google_oauth2,
+                  ENV["GOOGLE_CLIENT_ID"],
                   ENV["GOOGLE_CLIENT_SECRET"],
                   {
                     provider_ignores_state: true,
-                    scope: 'email,profile',
+                    scope: "email,profile",
                     redirect_uri: "http://localhost:3000/users/auth/google_oauth2/callback"
                   }
 
   # Enable OmniAuth test mode in development
-  OmniAuth.config.allowed_request_methods = [:post, :get] if Rails.env.development?
+  OmniAuth.config.allowed_request_methods = [ :post, :get ] if Rails.env.development?
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -277,7 +277,8 @@ Devise.setup do |config|
                   ENV["GOOGLE_CLIENT_SECRET"],
                   {
                     provider_ignores_state: true,
-                    scope: 'email,profile'
+                    scope: 'email,profile',
+                    redirect_uri: "http://localhost:3000/users/auth/google_oauth2/callback"
                   }
 
   # Enable OmniAuth test mode in development

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,17 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"]
+  config.omniauth :google_oauth2, 
+                  ENV["GOOGLE_CLIENT_ID"], 
+                  ENV["GOOGLE_CLIENT_SECRET"],
+                  {
+                    provider_ignores_state: true,
+                    scope: 'email,profile'
+                  }
+
+  # Enable OmniAuth test mode in development
+  OmniAuth.config.allowed_request_methods = [:post, :get] if Rails.env.development?
+
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   get "other_users/show"
   get "otherusers/show"
   get "others_journal/index"
-  devise_for :users
+  devise_for :users, controllers: {
+    omniauth_callbacks: 'users/omniauth_callbacks'
+  }
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   get "otherusers/show"
   get "others_journal/index"
   devise_for :users, controllers: {
-    omniauth_callbacks: 'users/omniauth_callbacks'
+    omniauth_callbacks: "users/omniauth_callbacks"
   }
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,8 +107,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_30_150154) do
     t.datetime "updated_at", null: false
     t.text "bio"
     t.string "x_link"
+    t.string "uid"
+    t.string "provider", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
# Google OAuth2ログイン機能の実装

## 概要
ユーザーがGoogleアカウントを使用してログインできる機能を追加しました。既存のメール/パスワード認証と併用可能で、同じメールアドレスのアカウントは自動的に連携されます。

## 主な変更点
1. Google OAuth2認証の実装
   - `devise`の`omniauthable`モジュールを使用
   - Google OAuth2の設定を追加
   - 認証コールバック処理の実装

2. ユーザーモデルの拡張
   - OAuth認証情報（provider, uid）の追加
   - [from_omniauth](cci:1://file:///Users/kogoro/MySongJorunal/app/models/user.rb:39:2-53:5)メソッドの実装
   - 既存アカウントとの連携機能

3. エラーハンドリングの改善
   - 認証失敗時のエラーメッセージ表示
   - デバッグ用ログの追加

4. マイグレーション
   - `name`カラムのnull制約対応
   - 既存レコードの`name`カラムを空文字で更新

## テスト項目
- [ ] 新規ユーザーのGoogle認証での登録
- [ ] 既存ユーザーのGoogle認証の追加
- [ ] 通常のメール/パスワードでのログイン維持
- [ ] エラー時の適切なメッセージ表示

## 動作確認方法
1. 通常のメール/パスワードで新規登録
2. 同じメールアドレスでGoogle認証を試行
3. 別のGoogleアカウントで新規登録
4. それぞれのアカウントでログイン/ログアウト

## 環境変数の設定
以下の環境変数の設定が必要です：
- `GOOGLE_CLIENT_ID`
- `GOOGLE_CLIENT_SECRET`
