### PR TITLE
本番環境用のcallbackを設定

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -278,7 +278,7 @@ Devise.setup do |config|
                   {
                     provider_ignores_state: true,
                     scope: "email,profile",
-                    redirect_uri: "http://localhost:3000/users/auth/google_oauth2/callback"
+                    redirect_uri: ENV["GOOGLE_REDIRECT_URI_PRODUCTION"] || "http://localhost:3000/users/auth/google_oauth2/callback"
                   }
 
   # Enable OmniAuth test mode in development


### PR DESCRIPTION
## 概要
- `config/initializers/devise.rb`に本番環境用の記載を追加


## 変更内容
    redirect_uri: ENV["GOOGLE_REDIRECT_URI_PRODUCTION"] || "http://localhost:3000/users/auth/google_oauth2/callback"としました