### PR TITLE
feat/AWSS3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ gem "kaminari"
 gem "mini_magick"
 gem "image_processing", "~> 1.2"
 gem "meta-tags", require: "meta_tags"
+gem "aws-sdk-s3"
 
 # Security
 gem "rack-attack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,22 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.1044.0)
+    aws-sdk-core (3.217.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.97.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-s3 (1.179.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
     benchmark (0.4.0)
@@ -158,6 +174,7 @@ GEM
     jbuilder (2.13.0)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.9.0)
@@ -437,6 +454,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap
   brakeman
   capybara

--- a/compose.yml
+++ b/compose.yml
@@ -29,6 +29,10 @@ services:
     environment:
       TZ: Asia/Tokyo
       REDIS_URL: redis://redis:6379/0
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_REGION: ${AWS_REGION}
+      AWS_BUCKET_NAME: ${AWS_BUCKET_NAME}
     ports:
       - "3000:3000"
     depends_on:
@@ -50,6 +54,10 @@ services:
       TZ: Asia/Tokyo
       REDIS_URL: redis://redis:6379/0
       POSTGRES_PASSWORD: password
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+      AWS_REGION: ${AWS_REGION}
+      AWS_BUCKET_NAME: ${AWS_BUCKET_NAME}
     depends_on:
       - db
       - redis

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,13 +6,15 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
-# Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+amazon:
+  service: S3
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+  region: <%= ENV['AWS_REGION'] %>
+  bucket: <%= ENV['AWS_BUCKET_NAME'] %>
+  force_path_style: true
+  upload:
+    acl: 'bucket-owner-full-control'
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:


### PR DESCRIPTION
## 概要
プロフィール画像の保存先をAWS S3に変更し、永続的なストレージを実現。これにより、Dockerコンテナ再起動時でも画像データが維持され、より安定したサービスを提供できるようになります。

## 変更内容
### 機能追加
- AWS S3を使用した画像ストレージの実装
  - `aws-sdk-s3` gemの追加
  - Active StorageのサービスをAWS S3に変更
  - プロフィール画像のアップロード機能の修正

### 設定変更
- AWS S3関連の環境変数の追加（.envファイル）
- `config/storage.yml`の更新
  - S3の設定を追加
  - アップロードACLの設定
- `config/environments/development.rb`の更新
  - Active StorageのサービスをS3に変更
- `compose.yml`の更新
  - AWS環境変数の追加

## 動作確認項目
- [ ] プロフィール画像のアップロードが正常に動作する
  - [ ] 新規アップロード
  - [ ] 画像の更新
- [ ] アップロードした画像がS3に保存される
  - [ ] S3コンソールで確認
- [ ] プロフィール画像が正しく表示される
  - [ ] コンテナ再起動後も画像が維持される
  - [ ] 環境変数が正しく読み込まれる

## 技術的変更点
- Active StorageのサービスをS3に変更
  - バケット名: mysongjournal
  - リージョン: ap-northeast-1
- S3バケットポリシーの設定
  - GetObject, PutObject, DeleteObjectの権限設定
- Docker環境での環境変数の設定
  - web, sidekiqコンテナに環境変数を追加

## セキュリティ関連
- AWS認証情報は環境変数で管理
  - .envファイルをgitignoreに追加
- S3バケットのアクセス権限を適切に設定
  - パブリックアクセスをブロック
  - バケットポリシーで必要最小限の権限を付与
- プライベートな画像アクセスの制御
  - 署名付きURLを使用

## 特記事項
- 本番環境へのデプロイ時にはS3バケットの設定が必要
- 既存の画像データの移行が必要な場合は別途対応が必要
- S3の無料枠を超えないよう、画像サイズの制限を検討する必要あり
