### PR TITLE
URLをわかりやすく改善し、ジャンル絞り込みを修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,10 @@ source "https://rubygems.org"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2"
+
+# URLをわかりやすく
+gem 'friendly_id', '~> 5.5.0'
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 # Use postgresql as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     ffi (1.17.1-x86-linux-gnu)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
+    friendly_id (5.5.1)
+      activerecord (>= 4.0.0)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
@@ -464,6 +466,7 @@ DEPENDENCIES
   devise-i18n
   devise-i18n-views
   dotenv-rails
+  friendly_id (~> 5.5.0)
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -13,9 +13,11 @@ class JournalsController < ApplicationController
     session.delete(:selected_track)
     session.delete(:journal_form)
 
-    @journals = current_user.journals.order(created_at: :desc)
-    @journals = @journals.where(emotion: params[:emotion]) if params[:emotion].present?
-    @journals = @journals.page(params[:page]).per(6)  # 1ページあたり6件表示
+    @journals = current_user.journals
+      .by_genre(params[:genre])
+      .by_emotion(params[:emotion])
+      .order(created_at: :desc)
+      .page(params[:page])
 
     # デバッグログ
     @journals.each do |journal|
@@ -26,9 +28,11 @@ class JournalsController < ApplicationController
 
   # タイムライン表示
   def timeline
-    @journals = Journal.includes(:user).order(created_at: :desc)
-    @journals = @journals.where(emotion: params[:emotion]) if params[:emotion].present?
-    @journals = @journals.page(params[:page]).per(6)  # 1ページあたり6件表示
+    @journals = Journal.includes(:user)
+      .by_genre(params[:genre])
+      .by_emotion(params[:emotion])
+      .order(created_at: :desc)
+      .page(params[:page])
   end
 
   # 詳細表示

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -3,7 +3,7 @@ class SpotifyController < ApplicationController
   require "rest-client"
   require "json"
   require "net/http"
-# 🎵 検索機能
+# 検索機能
 def search
   @tracks = []
   query_parts = []
@@ -216,6 +216,38 @@ end
     end
   end
 
+  def artist_genres
+    return render json: { error: 'Track ID is required' }, status: :bad_request if params[:track_id].blank?
+
+    begin
+      token = get_spotify_access_token
+      
+      # トラック情報を取得してアーティストIDを取得
+      track_response = RestClient.get(
+        "https://api.spotify.com/v1/tracks/#{params[:track_id]}",
+        { Authorization: "Bearer #{token}" }
+      )
+      track_data = JSON.parse(track_response.body)
+      artist_id = track_data['artists'].first['id']
+
+      # アーティスト情報からジャンルを取得
+      artist_response = RestClient.get(
+        "https://api.spotify.com/v1/artists/#{artist_id}",
+        { Authorization: "Bearer #{token}" }
+      )
+      artist_data = JSON.parse(artist_response.body)
+      genres = artist_data['genres']
+
+      # ジャンルを判定
+      genre = determine_genre(genres)
+      
+      render json: { genre: genre }
+    rescue => e
+      Rails.logger.error "Error fetching Spotify genres: #{e.message}"
+      render json: { error: 'Failed to fetch genre information' }, status: :internal_server_error
+    end
+  end
+
   private
 
   def batch_fetch_artists(artist_ids, token)
@@ -276,5 +308,84 @@ end
     else
       Rails.logger.error "トークンの取得に失敗しました: #{response.body}"
     end
+  end
+
+  def get_spotify_access_token
+    response = RestClient.post('https://accounts.spotify.com/api/token',
+      {
+        grant_type: 'client_credentials',
+        client_id: ENV['SPOTIFY_CLIENT_ID'],
+        client_secret: ENV['SPOTIFY_CLIENT_SECRET']
+      },
+      {
+        content_type: 'application/x-www-form-urlencoded'
+      }
+    )
+    JSON.parse(response.body)['access_token']
+  end
+
+  def determine_genre(spotify_genres)
+    return nil if spotify_genres.blank?
+
+    spotify_genres = spotify_genres.map(&:downcase)
+    
+    # ジャンルごとのスコアを計算
+    scores = Hash.new(0)
+    
+    spotify_genres.each do |genre|
+      # J-POP関連
+      if genre =~ /j-pop|jpop|japanese|japan|shibuya-kei/
+        scores['j-pop'] += 1
+      end
+
+      # K-POP関連
+      if genre =~ /k-pop|kpop|korean|k-indie|k-rap/
+        scores['k-pop'] += 1
+      end
+
+      # アイドル関連
+      if genre =~ /idol|boy band|girl group/
+        scores['idol'] += 1
+      end
+
+      # ボーカロイド関連
+      if genre =~ /vocaloid|virtual singer|synthetic voice/
+        scores['vocaloid'] += 1
+      end
+
+      # ゲーム関連
+      if genre =~ /game|gaming|chiptune|8-bit|16-bit/
+        scores['game'] += 1
+      end
+
+      # クラシック関連
+      if genre =~ /classical|orchestra|symphony|chamber|baroque|opera|concerto/
+        scores['classical'] += 1
+      end
+
+      # ジャズ関連
+      if genre =~ /jazz|bebop|swing|fusion|big band/
+        scores['jazz'] += 1
+      end
+
+      # 洋楽関連
+      if genre =~ /pop|rock|hip hop|rap|r&b|dance|electronic|soul|blues|folk|country|indie|alternative|metal|punk|reggae|latin/
+        scores['western'] += 1
+      end
+    end
+
+    # スコアが最も高いジャンルを選択
+    return nil if scores.empty?
+    
+    max_score = scores.values.max
+    candidates = scores.select { |k, v| v == max_score }.keys
+    
+    # 優先順位: より具体的なジャンル > 一般的なジャンル
+    priority_order = ['vocaloid', 'game', 'classical', 'jazz', 'idol', 'k-pop', 'j-pop', 'western']
+    priority_order.each do |genre|
+      return genre if candidates.include?(genre)
+    end
+
+    'others'
   end
 end

--- a/app/javascript/controllers/spotify_search_controller.js
+++ b/app/javascript/controllers/spotify_search_controller.js
@@ -95,4 +95,61 @@ export default class extends Controller {
       conditions[conditions.length - 1].remove()
     }
   }
+
+  selectTrack(event) {
+    const track = event.currentTarget.dataset;
+    
+    // フォームに値をセット
+    this.songNameTarget.value = track.songName;
+    this.artistNameTarget.value = track.artistName;
+    this.albumImageTarget.value = track.albumImage;
+    this.previewUrlTarget.value = track.previewUrl;
+    this.spotifyTrackIdTarget.value = track.spotifyTrackId;
+
+    // ジャンルを自動判定
+    this.determineGenre(track.artistName, track.songName, track.spotifyTrackId);
+
+    // モーダルを閉じる
+    this.closeModal();
+  }
+
+  async determineGenre(artistName, songName, trackId) {
+    // アニメ/特撮の判定（クライアントサイド）
+    if (this.isAnimeOrTokusatsu(artistName, songName)) {
+      this.genreTarget.value = 'anime';
+      return;
+    }
+
+    if (!trackId) {
+      this.genreTarget.value = '';
+      return;
+    }
+
+    try {
+      // アーティストの情報を取得
+      const response = await fetch(`/api/spotify/artist_genres?track_id=${trackId}`);
+      if (!response.ok) throw new Error('Failed to fetch artist genres');
+      
+      const data = await response.json();
+      if (data.genre) {
+        this.genreTarget.value = data.genre;
+      } else {
+        this.genreTarget.value = '';
+      }
+    } catch (error) {
+      console.error('Error determining genre:', error);
+      this.genreTarget.value = '';
+    }
+  }
+
+  isAnimeOrTokusatsu(artistName, songName) {
+    const animePatterns = [
+      /仮面ライダー|スーパー戦隊|戦隊|ウルトラマン|プリキュア|特撮|アニメ|disney|ディズニー|ジブリ|pixar|ピクサー/i,
+      /山寺宏一|水木一郎|堀江美都子|ささきいさお|串田アキラ|影山ヒロノブ|池田直樹|遠藤正明|宮内タカユキ|高橋秀幸|松本梨香|林原めぐみ|水樹奈々|田村ゆかり|堀江由衣|中川翔子|JAM Project|きただにひろし|米倉千尋|奥井雅美|鮎川麻弥|堀江晶太|岡崎律子|GRANRODEO|angela|fripSide|May'n|藍井エイル|LiSA|ClariS|小倉唯|沢城みゆき|花澤香菜|戸松遥/i
+    ];
+
+    return animePatterns.some(pattern => 
+      pattern.test(artistName) || pattern.test(songName)
+    );
+  }
 }

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -1,115 +1,194 @@
 class Journal < ApplicationRecord
+  extend FriendlyId
+  friendly_id :slug_candidates, use: :slugged
+
   belongs_to :user
-  enum emotion: { 喜: 0, 怒: 1, 哀: 2, 楽: 3 }
-  validates :title, presence: true, length: { maximum: 50 } # 必須、最大50文字
+  has_many :favorites, dependent: :destroy
+  has_many :favorited_users, through: :favorites, source: :user
+
+  # バリデーション
+  validates :title, presence: true, length: { maximum: 20 } # 必須、最大20文字
   validates :content, presence: true, length: { maximum: 500 } # 必須、最大500文字
   validates :emotion, presence: true # 必須
   validates :song_name, presence: true, length: { maximum: 100 }
   validates :artist_name, presence: true, length: { maximum: 100 }
   validates :album_image, presence: true, format: { with: URI.regexp(%w[http https]), message: "must be a valid URL" }
   validates :preview_url, format: { with: URI.regexp(%w[http https]), message: "must be a valid URL" }, allow_blank: true
-  has_many :favorites, dependent: :destroy
-  has_many :favorited_users, through: :favorites, source: :user
 
-  def favorited_by?(user)
-    favorites.exists?(user_id: user.id)
-  end
+  # 列挙型
+  enum genre: {
+    j_pop: 'j-pop',
+    k_pop: 'k-pop',
+    western: 'western',
+    anime: 'anime',
+    vocaloid: 'vocaloid',
+    others: 'others'
+  }
 
-  # 感情での絞り込み
-  scope :by_emotion, ->(emotion) { where(emotion: emotion) if emotion.present? }
+  enum emotion: [ :喜, :怒, :哀, :楽 ]
 
-  # 主要なジャンルの定義
+  # ジャンルの表示名と値のマッピング
   MAIN_GENRES = {
     'j-pop' => 'J-POP',
     'k-pop' => 'K-POP',
     'western' => '洋楽',
     'anime' => 'アニメ/特撮',
-    'idol' => 'アイドル/ボーカロイド',
+    'vocaloid' => 'ボーカロイド',
     'others' => 'その他'
   }.freeze
 
-  # Spotifyのジャンルタグをメインジャンルにマッピング
-  GENRE_MAPPING = {
-    # J-POP
-    'j-pop' => 'j-pop',
-    'j-rock' => 'j-pop',
-    'japanese indie' => 'j-pop',
-    'japanese singer-songwriter' => 'j-pop',
-    
-    # K-POP
-    'k-pop' => 'k-pop',
-    'k-rap' => 'k-pop',
-    'korean pop' => 'k-pop',
-    
-    # 洋楽
-    'pop' => 'western',
-    'rock' => 'western',
-    'rap' => 'western',
-    'r&b' => 'western',
-    'hip hop' => 'western',
-    
-    # アニメ/特撮
-    'anime' => 'anime',
-    'game' => 'anime',
-    'soundtrack' => 'anime',
-    
-    # アイドル/ボーカロイド
-    'idol' => 'idol',
-    'vocaloid' => 'idol',
-    'jpop idol' => 'idol'
-  }.freeze
-
-  # ジャンルでの絞り込み
+  # スコープ定義
+  scope :by_emotion, ->(emotion) { where(emotion: emotion) if emotion.present? }
   scope :by_genre, ->(genre) { where(genre: genre) if genre.present? }
-  
-  # Spotifyのジャンルを主要ジャンルに変換
-  def categorize_genre(spotify_genres)
-    return 'others' if spotify_genres.blank?
+
+  def favorited_by?(user)
+    favorites.exists?(user_id: user.id)
+  end
+
+  # ジャンルの表示名
+  def genre_display_name
+    case genre
+    when 'j-pop' then 'J-POP'
+    when 'k-pop' then 'K-POP'
+    when 'western' then '洋楽'
+    when 'anime' then 'アニメ/特撮'
+    when 'vocaloid' then 'ボーカロイド'
+    when 'others', nil then 'その他'
+    end
+  end
+
+  # 既存のジャンルを新しい体系に移行
+  def self.migrate_genres
+    find_each do |journal|
+      next if journal.genre.blank?
+      
+      # 現在のジャンルに基づいて新しいジャンルを設定
+      new_genre = case journal.genre.downcase
+      when 'j-pop', 'jpop', 'japanese'
+        'j-pop'
+      when 'k-pop', 'kpop', 'korean'
+        'k-pop'
+      when 'western', 'pop', 'rock', 'jazz', 'classical'
+        'western'
+      when 'anime', 'tokusatsu', 'game'
+        'anime'
+      when 'vocaloid'
+        'vocaloid'
+      else
+        'others'
+      end
+
+      # 新しいジャンルを設定して保存
+      journal.update_column(:genre, new_genre)
+    end
+
+    # 移行結果を表示
+    puts "\n=== ジャンル移行結果 ==="
+    group_counts = group(:genre).count
+    group_counts.each do |genre, count|
+      display_name = case genre
+      when 'j-pop' then 'J-POP'
+      when 'k-pop' then 'K-POP'
+      when 'western' then '洋楽'
+      when 'anime' then 'アニメ/特撮'
+      when 'vocaloid' then 'ボーカロイド'
+      else 'その他'
+      end
+      puts "#{display_name}: #{count}件"
+    end
+  end
+
+  private
+
+  def slug_candidates
+    [
+      :title,
+      [:title, :artist_name],
+      [:title, :artist_name, -> { created_at.strftime('%Y%m%d') }]
+    ]
+  end
+
+  def should_generate_new_friendly_id?
+    title_changed? || artist_name_changed? || super
+  end
+
+  def set_genre_from_spotify
+    return if spotify_track_id.blank?
+    return if genre.present? # ユーザーが既にジャンルを設定している場合は自動設定をスキップ
+
+    # アーティスト名とタイトルからアニメ/特撮かどうかを判定
+    title_based_genre = determine_genre_from_title
+    if title_based_genre == 'anime'
+      self.genre = 'anime'
+      return
+    end
+
+    # アニメ/特撮でない場合はnilのままにして、ユーザーに選択してもらう
+    self.genre = nil
+  end
+
+  def determine_genre_from_title
+    artist_name_lower = artist_name.to_s.downcase
+    song_name_lower = song_name.to_s.downcase
     
-    spotify_genres.each do |genre|
-      GENRE_MAPPING.each do |pattern, main_genre|
-        return main_genre if genre.include?(pattern)
+    # アニメ/特撮関連の判定
+    if artist_name_lower =~ /(?:仮面ライダー|スーパー戦隊|戦隊|ウルトラマン|プリキュア|特撮|アニメ|disney|ディズニー|ジブリ|pixar|ピクサー)/ ||
+       song_name_lower =~ /(?:仮面ライダー|スーパー戦隊|戦隊|ウルトラマン|プリキュア|特撮|アニメ|disney|ディズニー)/ ||
+       artist_name_lower =~ /(?:山寺宏一|水木一郎|堀江美都子|ささきいさお|串田アキラ|影山ヒロノブ|池田直樹|遠藤正明|宮内タカユキ|高橋秀幸|松本梨香|林原めぐみ|水樹奈々|田村ゆかり|堀江由衣|中川翔子|JAM Project|きただにひろし|米倉千尋|奥井雅美|鮎川麻弥|堀江晶太|岡崎律子|GRANRODEO|angela|fripSide|May\'n|藍井エイル|LiSA|ClariS|小倉唯|沢城みゆき|花澤香菜|戸松遥|相川七瀬.*仮面ライダー|アラン.*メンケン)/
+      'anime'
+    else
+      nil
+    end
+  end
+
+  def self.get_spotify_access_token
+    response = RestClient.post('https://accounts.spotify.com/api/token',
+      {
+        grant_type: 'client_credentials',
+        client_id: ENV['SPOTIFY_CLIENT_ID'],
+        client_secret: ENV['SPOTIFY_CLIENT_SECRET']
+      },
+      {
+        content_type: 'application/x-www-form-urlencoded'
+      }
+    )
+    JSON.parse(response.body)['access_token']
+  end
+
+  # 既存の日記のジャンルを一括更新
+  def self.classify_genres
+    find_each do |journal|
+      next if journal.spotify_track_id.blank?
+
+      begin
+        token = get_spotify_access_token
+        
+        track_response = RestClient.get(
+          "https://api.spotify.com/v1/tracks/#{journal.spotify_track_id}",
+          { Authorization: "Bearer #{token}" }
+        )
+        track_data = JSON.parse(track_response.body)
+        artist_id = track_data['artists'].first['id']
+
+        artist_response = RestClient.get(
+          "https://api.spotify.com/v1/artists/#{artist_id}",
+          { Authorization: "Bearer #{token}" }
+        )
+        artist_data = JSON.parse(artist_response.body)
+        genres = artist_data['genres']
+
+        genre = determine_best_genre_match(genres.map(&:downcase))
+        journal.update(genre: genre)
+        puts "Updated journal #{journal.id} (#{journal.artist_name} - #{journal.song_name})"
+        puts "Genre: #{genre || 'undecided'}"
+        puts "Spotify genres: #{genres.join(', ')}"
+        puts "---"
+      rescue => e
+        puts "Error updating journal #{journal.id}: #{e.message}"
       end
     end
-    
-    'others'
   end
 
-  # 曲情報保存時にジャンルも保存
-  def fetch_and_save_genre
-    return unless spotify_track_id.present?
-    
-    begin
-      token = SpotifyToken.last
-      # アーティスト情報を取得
-      track_response = RestClient.get(
-        "https://api.spotify.com/v1/tracks/#{spotify_track_id}",
-        { 
-          Authorization: "Bearer #{token.access_token}",
-          accept: 'application/json'
-        }
-      )
-      track = JSON.parse(track_response.body)
-      
-      artist_response = RestClient.get(
-        "https://api.spotify.com/v1/artists/#{track['artists'].first['id']}",
-        { 
-          Authorization: "Bearer #{token.access_token}",
-          accept: 'application/json'
-        }
-      )
-      artist_info = JSON.parse(artist_response.body)
-      
-      # ジャンルを分類して保存
-      main_genre = categorize_genre(artist_info['genres'])
-      update(genre: main_genre)
-    rescue => e
-      Rails.logger.error "Error fetching genre: #{e.message}"
-    end
-  end
-
-  # 表示用のジャンル名を取得
-  def genre_display_name
-    MAIN_GENRES[genre] || 'その他'
-  end
+  require 'rest-client'
+  require 'json'
 end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -14,4 +14,102 @@ class Journal < ApplicationRecord
   def favorited_by?(user)
     favorites.exists?(user_id: user.id)
   end
+
+  # 感情での絞り込み
+  scope :by_emotion, ->(emotion) { where(emotion: emotion) if emotion.present? }
+
+  # 主要なジャンルの定義
+  MAIN_GENRES = {
+    'j-pop' => 'J-POP',
+    'k-pop' => 'K-POP',
+    'western' => '洋楽',
+    'anime' => 'アニメ/特撮',
+    'idol' => 'アイドル/ボーカロイド',
+    'others' => 'その他'
+  }.freeze
+
+  # Spotifyのジャンルタグをメインジャンルにマッピング
+  GENRE_MAPPING = {
+    # J-POP
+    'j-pop' => 'j-pop',
+    'j-rock' => 'j-pop',
+    'japanese indie' => 'j-pop',
+    'japanese singer-songwriter' => 'j-pop',
+    
+    # K-POP
+    'k-pop' => 'k-pop',
+    'k-rap' => 'k-pop',
+    'korean pop' => 'k-pop',
+    
+    # 洋楽
+    'pop' => 'western',
+    'rock' => 'western',
+    'rap' => 'western',
+    'r&b' => 'western',
+    'hip hop' => 'western',
+    
+    # アニメ/特撮
+    'anime' => 'anime',
+    'game' => 'anime',
+    'soundtrack' => 'anime',
+    
+    # アイドル/ボーカロイド
+    'idol' => 'idol',
+    'vocaloid' => 'idol',
+    'jpop idol' => 'idol'
+  }.freeze
+
+  # ジャンルでの絞り込み
+  scope :by_genre, ->(genre) { where(genre: genre) if genre.present? }
+  
+  # Spotifyのジャンルを主要ジャンルに変換
+  def categorize_genre(spotify_genres)
+    return 'others' if spotify_genres.blank?
+    
+    spotify_genres.each do |genre|
+      GENRE_MAPPING.each do |pattern, main_genre|
+        return main_genre if genre.include?(pattern)
+      end
+    end
+    
+    'others'
+  end
+
+  # 曲情報保存時にジャンルも保存
+  def fetch_and_save_genre
+    return unless spotify_track_id.present?
+    
+    begin
+      token = SpotifyToken.last
+      # アーティスト情報を取得
+      track_response = RestClient.get(
+        "https://api.spotify.com/v1/tracks/#{spotify_track_id}",
+        { 
+          Authorization: "Bearer #{token.access_token}",
+          accept: 'application/json'
+        }
+      )
+      track = JSON.parse(track_response.body)
+      
+      artist_response = RestClient.get(
+        "https://api.spotify.com/v1/artists/#{track['artists'].first['id']}",
+        { 
+          Authorization: "Bearer #{token.access_token}",
+          accept: 'application/json'
+        }
+      )
+      artist_info = JSON.parse(artist_response.body)
+      
+      # ジャンルを分類して保存
+      main_genre = categorize_genre(artist_info['genres'])
+      update(genre: main_genre)
+    rescue => e
+      Rails.logger.error "Error fetching genre: #{e.message}"
+    end
+  end
+
+  # 表示用のジャンル名を取得
+  def genre_display_name
+    MAIN_GENRES[genre] || 'その他'
+  end
 end

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -1,79 +1,93 @@
-<div class="bg-white rounded-lg shadow-sm p-4 relative" id="journal-card-<%= journal.id %>">
-  <div class="text-sm text-gray-600 text-right p-2">
-    <%= journal.created_at.strftime("%m/%d %H:%M") %>
-  </div>
-  <!-- ジャケット画像 -->
-  <div class="w-full aspect-square relative">
-    <%= image_tag(journal.album_image.presence || 'no-image.png',
-        class: "w-full h-full object-cover", 
-        loading: "lazy",
-        alt: "アルバムジャケット画像"
-    ) %>
-  </div>
-
-  <!-- 情報部分 -->
-  <div class="p-4">
-    <div class="mb-3">
-      <h3 class="font-bold text-lg mb-1"><%= journal.title %></h3>
-      <div class="flex items-center gap-2 text-sm text-gray-600">
+<div class="bg-gray-300 rounded-lg shadow h-full flex flex-col p-4">
+<!-- ヘッダー情報（タイトル、投稿者） -->
+<div class="flex flex-col">
+  <div class="flex justify-between text-sm text-gray-600 mb-1">
+    <div class="flex items-center gap-2">
+      <h3 class="font-bold text-lg line-clamp-2 flex-1">
+        <%= journal.title %>
+      </h3>
+      <div class="flex items-center gap-2">
         <span>by <%= journal.user.name %></span>
         <% if user_signed_in? && journal.user != current_user %>
           <%= render 'follows/button', user: journal.user %>
         <% end %>
       </div>
     </div>
+  </div>
+</div>
 
-    <!-- 曲情報 -->
-    <div class="text-sm text-gray-600 space-y-1 mb-4">
-      <div>アーティスト: <%= journal.artist_name %></div>
-      <div>曲名: <%= journal.song_name %></div>
-      <div class="inline-block px-2 py-1 bg-gray-200 rounded-full text-xs">
-        感情: <%= journal.emotion %>
+  <!-- ジャケット画像 -->
+  <div class="relative mb-4">
+    <%= image_tag journal.album_image.presence || 'no-image.png',
+        class: "w-full aspect-square object-cover rounded-lg",
+        alt: "アルバムジャケット画像" %>
+  </div>
+
+  <!-- 曲情報 -->
+  <div class="space-y-2 mb-4">
+    <div class="flex items-center gap-2 text-sm text-gray-600">
+      <span class="w-5 flex-shrink-0">🎤</span>
+      <span class="truncate"><%= journal.artist_name %></span>
+    </div>
+    <div class="flex items-center gap-2 text-sm text-gray-600">
+      <span class="w-5 flex-shrink-0">🎵</span>
+      <span class="truncate"><%= journal.song_name %></span>
+    </div>
+  </div>
+
+  <!-- タグ -->
+  <div class="flex flex-wrap gap-2 mb-4">
+    <div class="inline-flex items-center px-3 py-1 bg-red-500 text-white rounded-full text-xs min-w-[80px] justify-center">
+      <%= journal.emotion %>
+    </div>
+    <% if journal.genre.present? %>
+      <div class="inline-flex items-center px-3 py-1 bg-blue-500 text-white rounded-full text-xs min-w-[80px] justify-center">
+        <%= t("activerecord.attributes.journal.genre.#{journal.genre}") %>
       </div>
-    </div>
+      <div class="inline-flex items-center px-3 py-1 bg-green-500 text-white rounded-full text-xs min-w-[80px] justify-center">
+      <%= journal.created_at.strftime("%m/%d %H:%M") %>
+      </div>
+    <% end %>
+  </div>
 
-    <!-- アクションボタン -->
-    <div class="flex gap-2">
-      <% if user_signed_in? %>
-        <% if journal.user == current_user %>
-          <%= link_to '詳細', journal_path(journal), data: { turbo: false },
-              class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-gray-500 text-white text-sm rounded hover:bg-gray-600" %>
-          <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },
-              class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-yellow-500 text-white text-sm rounded hover:bg-yellow-600" %>
-          <%= button_to '削除', journal_path(journal),
-              method: :delete,
-              data: { turbo: false, confirm: "本当に削除しますか？" },
-              class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-red-500 text-white text-sm rounded hover:bg-red-600" %>
-        <% else %>
-          <%= link_to '詳細', journal_path(journal), data: { turbo: false },
-              class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-gray-500 text-white text-sm rounded hover:bg-gray-600" %>
-        <% end %>
-      <% else %>
+  <!-- アクションボタン -->
+  <div class="mt-auto space-y-2">
+    <% if user_signed_in? && journal.user == current_user %>
+      <div class="flex gap-2">
         <%= link_to '詳細', journal_path(journal), data: { turbo: false },
-            class: "flex-1 text-center py-2 px-4 min-w-[80px] bg-gray-500 text-white text-sm rounded hover:bg-gray-600" %>
-      <% end %>
-    </div>
-
-    <%# いいねボタン - 自分の投稿以外にのみ表示 %>
-    <% unless journal.user == current_user %>
-      <div class="mt-2" id="favorite-button-<%= journal.id %>">
+            class: "flex-1 text-center py-2 px-4 bg-gray-500 text-white text-sm rounded hover:bg-gray-600 min-w-[120px]" %>
+        <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },
+            class: "flex-1 text-center py-2 px-4 bg-yellow-500 text-white text-sm rounded hover:bg-yellow-600 min-w-[120px]" %>
+        <%= button_to journal_path(journal),
+            method: :delete,
+            data: { turbo: false, confirm: "本当に削除しますか？" },
+            class: "flex-1" do %>
+          <button type="submit" class="w-full text-center py-2 px-4 bg-red-500 text-white text-sm rounded hover:bg-red-600 min-w-[120px]">
+            削除
+          </button>
+        <% end %>
+      </div>
+    <% else %>
+      <div class="flex gap-2">
+        <%= link_to '詳細', journal_path(journal), data: { turbo: false },
+            class: "flex-1 text-center py-2 px-4 bg-gray-500 text-white text-sm rounded hover:bg-gray-600 min-w-[120px]" %>
         <% if user_signed_in? %>
           <% if journal.favorited_by?(current_user) %>
             <%= button_to journal_favorites_path(journal), method: :delete,
-                class: "w-full flex items-center justify-center gap-2 py-2 px-4 bg-pink-500 text-white text-sm rounded hover:bg-pink-600" do %>
+                class: "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-pink-500 text-white text-sm rounded hover:bg-pink-600 min-w-[120px]" do %>
               <i class="fas fa-heart"></i>
               <span><%= journal.favorites.count %></span>
             <% end %>
           <% else %>
             <%= button_to journal_favorites_path(journal), method: :post,
-                class: "w-full flex items-center justify-center gap-2 py-2 px-4 bg-green-500 text-white text-sm rounded hover:bg-green-600" do %>
+                class: "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-green-500 text-white text-sm rounded hover:bg-green-600 min-w-[120px]" do %>
               <i class="far fa-heart"></i>
               <span><%= journal.favorites.count %></span>
             <% end %>
           <% end %>
         <% else %>
           <%= link_to new_user_session_path,
-              class: "w-full flex items-center justify-center gap-2 py-2 px-4 bg-gray-300 text-white text-sm rounded" do %>
+              class: "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-gray-300 text-white text-sm rounded min-w-[120px]" do %>
             <i class="far fa-heart"></i>
             <span><%= journal.favorites.count %></span>
           <% end %>
@@ -81,4 +95,4 @@
       </div>
     <% end %>
   </div>
-</div> 
+</div>

--- a/app/views/journals/edit.html.erb
+++ b/app/views/journals/edit.html.erb
@@ -47,6 +47,20 @@
             </div>
           <% end %>
 
+          <!-- ジャンル選択 -->
+          <div class="mb-4">
+            <div class="form-group">
+              <%= form.label :genre, "ジャンル", class: "block text-md font-medium text-gray-700 mb-2" %>
+              <%= form.select :genre, 
+                Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+                { include_blank: '選択してください' },
+                { 
+                  class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                }
+              %>
+            </div>
+          </div>
+
           <% if @journal.preview_url.present? %>
             <div>
               <audio id="selected-audio" controls class="w-full rounded-lg">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -8,14 +8,25 @@
       <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
         <%= f.select :emotion,
             Journal.emotions.keys.map { |key| [key.humanize, key] },
-            { include_blank: "すべて", selected: params[:emotion] },
+            { include_blank: "すべての感情", selected: params[:emotion] },
             { 
               class: "px-4 py-2 border rounded-md bg-customred",
               onchange: "this.form.requestSubmit()"
             } 
         %>
+        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "genre-filter-form" do |f| %>
+          <%= f.select :genre,
+              Journal::MAIN_GENRES.map { |key, name| [name, key] },
+              { include_blank: "すべてのジャンル", selected: params[:genre] },
+              { 
+                class: "px-4 py-2 border rounded-md bg-customred",
+                onchange: "this.form.requestSubmit()"
+              } 
+          %>
+          <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+        <% end %>
+      </div>
       <% end %>
-    </div>
 
     <!-- 一覧表示 -->
     <ul class="grid grid-cols-2 gap-4">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -5,28 +5,47 @@
       <h1 class="text-2xl font-bold">
         <%= "#{current_user.name}'s Journal" %>
       </h1>
-      <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
-        <%= f.select :emotion,
-            Journal.emotions.keys.map { |key| [key.humanize, key] },
-            { include_blank: "すべての感情", selected: params[:emotion] },
-            { 
-              class: "px-4 py-2 border rounded-md bg-customred",
-              onchange: "this.form.requestSubmit()"
-            } 
-        %>
-        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "genre-filter-form" do |f| %>
-          <%= f.select :genre,
-              Journal::MAIN_GENRES.map { |key, name| [name, key] },
-              { include_blank: "すべてのジャンル", selected: params[:genre] },
-              { 
+      <div class="flex items-center gap-2">
+        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "sort-filter-form" do |f| %>
+          <%= f.select :sort,
+              [['新しい順', 'desc'], ['古い順', 'asc']],
+              { selected: params[:sort] || 'desc' },
+              {
                 class: "px-4 py-2 border rounded-md bg-customred",
                 onchange: "this.form.requestSubmit()"
-              } 
+              }
           %>
           <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+          <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+        <% end %>
+
+        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
+          <%= f.select :emotion,
+              Journal.emotions.keys.map { |key| [key.humanize, key] },
+              { include_blank: "すべての感情", selected: params[:emotion] },
+              {
+                class: "px-4 py-2 border rounded-md bg-customred",
+                onchange: "this.form.requestSubmit()"
+              }
+          %>
+          <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+          <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+        <% end %>
+
+        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "genre-filter-form" do |f| %>
+          <%= f.select :genre,
+              Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+              { include_blank: "すべてのジャンル", selected: params[:genre] },
+              {
+                class: "px-4 py-2 border rounded-md bg-customred",
+                onchange: "this.form.requestSubmit()"
+              }
+          %>
+          <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+          <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
         <% end %>
       </div>
-      <% end %>
+    </div>
 
     <!-- 一覧表示 -->
     <ul class="grid grid-cols-2 gap-4">
@@ -48,6 +67,7 @@
               <div class="text-sm text-gray-600 space-y-1">
                 <div>作成日: <%= journal.created_at.in_time_zone('Asia/Tokyo').strftime("%Y年%m月%d日 %H:%M") %></div>
                 <div>感情: <%= journal.emotion.presence || "未設定" %></div>
+                <div>ジャンル: <%= journal.genre.present? ? t("activerecord.attributes.journal.genre.#{journal.genre}") : "未設定" %></div>
                 <div>アーティスト名: <%= journal.artist_name.presence || "未設定" %></div>
                 <div>曲名: <%= journal.song_name.presence || "未設定" %></div>
               </div>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -25,6 +25,10 @@
         </div>
 
         <% if @journal.song_name.present? || @journal.artist_name.present? || @journal.album_image.present? %>
+          <div class="text-xl font-bold text-gray-800 mb-4">
+            🎵 選択した曲情報
+          </div>
+
           <% if @journal.artist_name.present? %>
             <div class="mb-2">
               <span id="selected-artist-name" class="block text-lg font-medium text-gray-800">
@@ -48,6 +52,20 @@
               </a>
             </div>
           <% end %>
+
+         <!-- ジャンル選択 -->
+          <div class="mb-4">
+            <div class="form-group">
+              <%= form.label :genre, "ジャンル", class: "block text-md font-medium text-gray-700 mb-2" %>
+              <%= form.select :genre, 
+                Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+                { include_blank: '選択してください' },
+                { 
+                  class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                }
+              %>
+            </div>
+          </div>
         <% else %>
           <p class="text-gray-500">まずは曲を選んでください♫</p>
         <% end %>

--- a/app/views/journals/timeline.html.erb
+++ b/app/views/journals/timeline.html.erb
@@ -6,39 +6,66 @@
         <h1 class="text-2xl font-bold">タイムライン</h1>
         <p class="text-sm text-gray-600 mt-1">*フォローボタンを押すと日記を書いたユーザーをフォローできます。</p>
       </div>
-      <%=
-        form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
-          <%= f.select :emotion,
-            Journal.emotions.keys.map { |key| [key.humanize, key] },
-            { include_blank: "すべての感情", selected: params[:emotion] },
-            { 
-              class: "px-4 py-2 border rounded-md bg-customred text-white",
-              onchange: "this.form.requestSubmit()"
-            } 
+      <div class="flex items-center gap-2">
+        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "sort-filter-form" do |f| %>
+          <%= f.select :sort,
+              [['新しい順', 'desc'], ['古い順', 'asc']],
+              { selected: params[:sort] || 'desc' },
+              {
+                class: "px-4 py-2 border rounded-md bg-customred",
+                onchange: "this.form.requestSubmit()"
+              }
           %>
-          <%= f.select :genre,
-            Journal::MAIN_GENRES.map { |key, name| [name, key] },
-            { include_blank: "すべてのジャンル", selected: params[:genre] },
-            { 
-              class: "px-4 py-2 border rounded-md bg-customred text-white",
-              onchange: "this.form.requestSubmit()"
-            } 
-          %>
+          <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+          <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
         <% end %>
+
+        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
+          <%= f.select :emotion,
+              Journal.emotions.keys.map { |key| [key.humanize, key] },
+              { include_blank: "すべての感情", selected: params[:emotion] },
+              {
+                class: "px-4 py-2 border rounded-md bg-customred",
+                onchange: "this.form.requestSubmit()"
+              }
+          %>
+          <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+          <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+        <% end %>
+
+        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "genre-filter-form" do |f| %>
+          <%= f.select :genre,
+              Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+              { include_blank: "すべてのジャンル", selected: params[:genre] },
+              {
+                class: "px-4 py-2 border rounded-md bg-customred",
+                onchange: "this.form.requestSubmit()"
+              }
+          %>
+          <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+          <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+        <% end %>
+      </div>
     </div>
 
     <!-- 日記カード一覧 -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-7xl mx-auto">
       <% @journals.each do |journal| %>
-        <div class="flex flex-col h-full">
+        <div class="h-full w-full">
           <%= render 'journals/journal_card', journal: journal %>
         </div>
       <% end %>
     </div>
 
     <!-- ページネーション -->
-    <div class="mt-6">
-      <%= paginate @journals %>
+    <div class="mt-6 flex justify-center">
+      <div class="flex items-center gap-2">
+        <%= paginate @journals, window: 2,
+            outer_window: 1,
+            class: "flex items-center gap-2",
+            previous_label: '前へ',
+            next_label: '次へ' %>
+      </div>
     </div>
 
     <!-- 新規作成ボタン -->

--- a/app/views/journals/timeline.html.erb
+++ b/app/views/journals/timeline.html.erb
@@ -6,16 +6,25 @@
         <h1 class="text-2xl font-bold">タイムライン</h1>
         <p class="text-sm text-gray-600 mt-1">*フォローボタンを押すと日記を書いたユーザーをフォローできます。</p>
       </div>
-       <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
-             <%= f.select :emotion,
+      <%=
+        form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
+          <%= f.select :emotion,
             Journal.emotions.keys.map { |key| [key.humanize, key] },
             { include_blank: "すべての感情", selected: params[:emotion] },
             { 
               class: "px-4 py-2 border rounded-md bg-customred text-white",
               onchange: "this.form.requestSubmit()"
             } 
-        %>
-      <% end %>
+          %>
+          <%= f.select :genre,
+            Journal::MAIN_GENRES.map { |key, name| [name, key] },
+            { include_blank: "すべてのジャンル", selected: params[:genre] },
+            { 
+              class: "px-4 py-2 border rounded-md bg-customred text-white",
+              onchange: "this.form.requestSubmit()"
+            } 
+          %>
+        <% end %>
     </div>
 
     <!-- 日記カード一覧 -->

--- a/config/initializers/friendly_id.rb
+++ b/config/initializers/friendly_id.rb
@@ -1,0 +1,107 @@
+# FriendlyId Global Configuration
+#
+# Use this to set up shared configuration options for your entire application.
+# Any of the configuration options shown here can also be applied to single
+# models by passing arguments to the `friendly_id` class method or defining
+# methods in your model.
+#
+# To learn more, check out the guide:
+#
+# http://norman.github.io/friendly_id/file.Guide.html
+
+FriendlyId.defaults do |config|
+  # ## Reserved Words
+  #
+  # Some words could conflict with Rails's routes when used as slugs, or are
+  # undesirable to allow as slugs. Edit this list as needed for your app.
+  config.use :reserved
+
+  config.reserved_words = %w[new edit index session login logout users admin
+    stylesheets assets javascripts images]
+
+  # This adds an option to treat reserved words as conflicts rather than exceptions.
+  # When there is no good candidate, a UUID will be appended, matching the existing
+  # conflict behavior.
+
+  # config.treat_reserved_as_conflict = true
+
+  #  ## Friendly Finders
+  #
+  # Uncomment this to use friendly finders in all models. By default, if
+  # you wish to find a record by its friendly id, you must do:
+  #
+  #    MyModel.friendly.find('foo')
+  #
+  # If you uncomment this, you can do:
+  #
+  #    MyModel.find('foo')
+  #
+  # This is significantly more convenient but may not be appropriate for
+  # all applications, so you must explicitly opt-in to this behavior. You can
+  # always also configure it on a per-model basis if you prefer.
+  #
+  # Something else to consider is that using the :finders addon boosts
+  # performance because it will avoid Rails-internal code that makes runtime
+  # calls to `Module.extend`.
+  #
+  # config.use :finders
+  #
+  # ## Slugs
+  #
+  # Most applications will use the :slugged module everywhere. If you wish
+  # to do so, uncomment the following line.
+  #
+  # config.use :slugged
+  #
+  # By default, FriendlyId's :slugged addon expects the slug column to be named
+  # 'slug', but you can change it if you wish.
+  #
+  # config.slug_column = 'slug'
+  #
+  # By default, slug has no size limit, but you can change it if you wish.
+  #
+  # config.slug_limit = 255
+  #
+  # When FriendlyId can not generate a unique ID from your base method, it appends
+  # a UUID, separated by a single dash. You can configure the character used as the
+  # separator. If you're upgrading from FriendlyId 4, you may wish to replace this
+  # with two dashes.
+  #
+  # config.sequence_separator = '-'
+  #
+  # Note that you must use the :slugged addon **prior** to the line which
+  # configures the sequence separator, or else FriendlyId will raise an undefined
+  # method error.
+  #
+  #  ## Tips and Tricks
+  #
+  #  ### Controlling when slugs are generated
+  #
+  # As of FriendlyId 5.0, new slugs are generated only when the slug field is
+  # nil, but if you're using a column as your base method can change this
+  # behavior by overriding the `should_generate_new_friendly_id?` method that
+  # FriendlyId adds to your model. The change below makes FriendlyId 5.0 behave
+  # more like 4.0.
+  # Note: Use(include) Slugged module in the config if using the anonymous module.
+  # If you have `friendly_id :name, use: slugged` in the model, Slugged module
+  # is included after the anonymous module defined in the initializer, so it
+  # overrides the `should_generate_new_friendly_id?` method from the anonymous module.
+  #
+  # config.use :slugged
+  # config.use Module.new {
+  #   def should_generate_new_friendly_id?
+  #     slug.blank? || <your_column_name_here>_changed?
+  #   end
+  # }
+  #
+  # FriendlyId uses Rails's `parameterize` method to generate slugs, but for
+  # languages that don't use the Roman alphabet, that's not usually sufficient.
+  # Here we use the Babosa library to transliterate Russian Cyrillic slugs to
+  # ASCII. If you use this, don't forget to add "babosa" to your Gemfile.
+  #
+  # config.use Module.new {
+  #   def normalize_friendly_id(text)
+  #     text.to_slug.normalize! :transliterations => [:russian, :latin]
+  #   end
+  # }
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -17,6 +17,14 @@ ja:
         x_link: "Xのリンク"
         avatar: "アバター画像"
         update: "更新"
+      journal:
+        genre:
+          j_pop: "J-POP"
+          k_pop: "K-POP"
+          western: "洋楽"
+          anime: "アニメ/特撮"
+          vocaloid: "ボーカロイド"
+          others: "その他"
   time:
     formats:
       long: "%Y年%m月%d日 %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   get "/spotify/results", to: "spotify#results", as: "spotify_results"
   post "spotify/select_tracks", to: "spotify#select_tracks", as: :select_tracks
   get "spotify/autocomplete", to: "spotify#autocomplete"
+  get 'spotify/artist_genres', to: 'spotify#artist_genres'
 
   # 静的ページのルート
   get "/privacy_policy", to: "pages#privacy_policy"

--- a/db/migrate/20250204092950_add_genre_to_journals.rb
+++ b/db/migrate/20250204092950_add_genre_to_journals.rb
@@ -1,0 +1,5 @@
+class AddGenreToJournals < ActiveRecord::Migration[7.2]
+  def change
+    add_column :journals, :genre, :string
+  end
+end

--- a/db/migrate/20250204140146_add_slug_to_journals.rb
+++ b/db/migrate/20250204140146_add_slug_to_journals.rb
@@ -1,0 +1,6 @@
+class AddSlugToJournals < ActiveRecord::Migration[7.2]
+  def change
+    add_column :journals, :slug, :string
+    add_index :journals, :slug, unique: true
+  end
+end

--- a/db/migrate/20250204140534_create_friendly_id_slugs.rb
+++ b/db/migrate/20250204140534_create_friendly_id_slugs.rb
@@ -1,0 +1,21 @@
+MIGRATION_CLASS =
+  if ActiveRecord::VERSION::MAJOR >= 5
+    ActiveRecord::Migration["#{ActiveRecord::VERSION::MAJOR}.#{ActiveRecord::VERSION::MINOR}"]
+  else
+    ActiveRecord::Migration
+  end
+
+class CreateFriendlyIdSlugs < MIGRATION_CLASS
+  def change
+    create_table :friendly_id_slugs do |t|
+      t.string :slug, null: false
+      t.integer :sluggable_id, null: false
+      t.string :sluggable_type, limit: 50
+      t.string :scope
+      t.datetime :created_at
+    end
+    add_index :friendly_id_slugs, [:sluggable_type, :sluggable_id]
+    add_index :friendly_id_slugs, [:slug, :sluggable_type], length: {slug: 140, sluggable_type: 50}
+    add_index :friendly_id_slugs, [:slug, :sluggable_type, :scope], length: {slug: 70, sluggable_type: 50, scope: 70}, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_03_111642) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_04_092950) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_03_111642) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "spotify_track_id"
+    t.string "genre"
     t.index ["user_id"], name: "index_journals_on_user_id"
   end
 
@@ -115,10 +116,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_03_111642) do
     t.datetime "updated_at", null: false
     t.text "bio"
     t.string "x_link"
-    t.string "provider"
     t.string "uid"
+    t.string "provider", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
     t.index ["x_link"], name: "index_users_on_x_link", unique: true, where: "(x_link IS NOT NULL)"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_04_092950) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_04_140534) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -70,6 +70,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_04_092950) do
     t.index ["follower_id"], name: "index_follows_on_follower_id"
   end
 
+  create_table "friendly_id_slugs", force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
+
   create_table "journals", force: :cascade do |t|
     t.string "title", null: false
     t.text "content", null: false
@@ -83,6 +94,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_04_092950) do
     t.datetime "updated_at", null: false
     t.string "spotify_track_id"
     t.string "genre"
+    t.string "slug"
+    t.index ["slug"], name: "index_journals_on_slug", unique: true
     t.index ["user_id"], name: "index_journals_on_user_id"
   end
 
@@ -116,11 +129,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_04_092950) do
     t.datetime "updated_at", null: false
     t.text "bio"
     t.string "x_link"
+    t.string "provider"
     t.string "uid"
-    t.string "provider", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
-    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
     t.index ["x_link"], name: "index_users_on_x_link", unique: true, where: "(x_link IS NOT NULL)"
   end
 


### PR DESCRIPTION
## 変更内容
1. friendly_idを導入してURLを改善
   - 数字のIDの代わりに、タイトルベースのURLを使用
   - 例: `/journals/43` → `/journals/happy-birthday-back-number`
   - 重複時はアーティスト名と日付を追加

2. ジャンル絞り込みの修正
   - 感情とジャンルの組み合わせフィルターを修正
   - 各フィルターを独立して機能するように変更

3. その他の改善
   - タイトルの最大文字数を50文字から20文字に変更
   - メタタグの不要な絵文字を削除
   - キーワードを整理

## テスト項目
- [ ] 既存の日記URLが新形式に変換されること
- [ ] 新規作成時にわかりやすいURLが生成されること
- [ ] 感情とジャンルの絞り込みが個別に機能すること
- [ ] タイトルが20文字以内で保存できること
