### PR TITLE
Feat/track

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -94,7 +94,6 @@ class JournalsController < ApplicationController
         album_image: session[:selected_track]["album_image"],
         preview_url: session[:selected_track]["preview_url"],
         spotify_track_id: session[:selected_track]["spotify_track_id"],
-        spotify_url: session[:selected_track]["spotify_url"]
       )
     end
 

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -201,15 +201,15 @@ class JournalsController < ApplicationController
 
   def journal_params
     params.require(:journal).permit(
-      :title, 
-      :content, 
-      :emotion, 
-      :genre, 
-      :song_name, 
-      :artist_name, 
-      :album_name, 
-      :album_image, 
-      :preview_url, 
+      :title,
+      :content,
+      :emotion,
+      :genre,
+      :song_name,
+      :artist_name,
+      :album_name,
+      :album_image,
+      :preview_url,
       :spotify_url,
       :spotify_track_id
     )

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -86,14 +86,23 @@ class JournalsController < ApplicationController
   def create
     @journal = current_user.journals.build(journal_params)
 
-    # ジャンルは自動的に設定される（before_create :set_genre_from_spotifyで）
+    # セッションから曲の情報を復元（spotify_track_idを含む）
+    if session[:selected_track].present?
+      @journal.assign_attributes(
+        song_name: session[:selected_track]["song_name"],
+        artist_name: session[:selected_track]["artist_name"],
+        album_image: session[:selected_track]["album_image"],
+        preview_url: session[:selected_track]["preview_url"],
+        spotify_track_id: session[:selected_track]["spotify_track_id"],
+        spotify_url: session[:selected_track]["spotify_url"]
+      )
+    end
 
     if @journal.save
       # セッションをクリア
       session.delete(:selected_track)
       session.delete(:journal_form)
 
-      # 保存成功後は詳細ページにリダイレクト
       redirect_to @journal, notice: "日記を保存しました。"
     else
       Rails.logger.error "Journal save failed: #{@journal.errors.full_messages}"
@@ -112,6 +121,18 @@ class JournalsController < ApplicationController
   def update
     @journal = current_user.journals.friendly.find(params[:id])
     Rails.logger.info "🔄 Update action called with edit_source: #{session[:edit_source]}"
+
+    # セッションから曲の情報を復元（spotify_track_idを含む）
+    if session[:selected_track].present?
+      params[:journal].merge!(
+        song_name: session[:selected_track]["song_name"],
+        artist_name: session[:selected_track]["artist_name"],
+        album_image: session[:selected_track]["album_image"],
+        preview_url: session[:selected_track]["preview_url"],
+        spotify_track_id: session[:selected_track]["spotify_track_id"],
+        spotify_url: session[:selected_track]["spotify_url"]
+      )
+    end
 
     if @journal.update(journal_params)
       flash[:notice] = "日記を更新しました"
@@ -180,7 +201,19 @@ class JournalsController < ApplicationController
   end
 
   def journal_params
-    params.require(:journal).permit(:title, :content, :emotion, :genre, :song_name, :artist_name, :album_name, :album_image, :preview_url, :spotify_url)
+    params.require(:journal).permit(
+      :title, 
+      :content, 
+      :emotion, 
+      :genre, 
+      :song_name, 
+      :artist_name, 
+      :album_name, 
+      :album_image, 
+      :preview_url, 
+      :spotify_url,
+      :spotify_track_id
+    )
   end
 
   def store_edit_source

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -63,9 +63,11 @@ def search
       "https://api.spotify.com/v1/search",
       {
         Authorization: "Bearer #{token}",
+        "Accept-Language" => "ja",  # 日本語表記を優先
         params: {
           q: query_string,
           type: 'track',
+          market: 'JP',  # 日本のマーケットに限定
           limit: @per_page,
           offset: offset
         }

--- a/app/controllers/spotify_controller.rb
+++ b/app/controllers/spotify_controller.rb
@@ -66,8 +66,8 @@ def search
         "Accept-Language" => "ja",  # 日本語表記を優先
         params: {
           q: query_string,
-          type: 'track',
-          market: 'JP',  # 日本のマーケットに限定
+          type: "track",
+          market: "JP",  # 日本のマーケットに限定
           limit: @per_page,
           offset: offset
         }

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -104,7 +104,7 @@ class Journal < ApplicationRecord
     [
       :title,
       [ :title, :artist_name ],
-      [ :title, :artist_name, -> { created_at.strftime("%Y%m%d") } ]
+      [ :title, :artist_name, -> { (created_at || Time.current).strftime("%Y%m%d") } ]
     ]
   end
 

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -1,4 +1,4 @@
-<div class="bg-gray-300 rounded-lg shadow p-6">
+<div class="bg-gray-300 rounded-lg shadow p-6 text-gray-700">
   <!-- ヘッダー情報（タイトル、投稿者） -->
   <div class="flex flex-col mb-6">
     <div class="flex justify-start gap-2 items-center">

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -1,86 +1,96 @@
-<div class="bg-gray-300 rounded-lg shadow h-full flex flex-col p-4">
-<!-- ヘッダー情報（タイトル、投稿者） -->
-<div class="flex flex-col">
-  <div class="flex justify-between text-sm text-gray-600 mb-1">
-    <div class="flex items-center gap-2">
-      <h3 class="font-bold text-lg line-clamp-2 flex-1">
+<div class="bg-gray-300 rounded-lg shadow p-6">
+  <!-- ヘッダー情報（タイトル、投稿者） -->
+  <div class="flex flex-col mb-6">
+    <div class="flex justify-start gap-2 items-center">
+      <h3 class="font-bold text-xl">
         <%= journal.title %>
       </h3>
-      <div class="flex items-center gap-2">
-        <span>by <%= journal.user.name %></span>
+      <div class="flex items-center gap-4">
+        <span class="text-base">by <%= journal.user.name %></span>
         <% if user_signed_in? && journal.user != current_user %>
           <%= render 'follows/button', user: journal.user %>
         <% end %>
       </div>
     </div>
   </div>
-</div>
 
-  <!-- ジャケット画像 -->
-  <div class="relative mb-4">
-    <%= image_tag journal.album_image.presence || 'no-image.png',
-        class: "w-full aspect-square object-cover rounded-lg",
-        alt: "アルバムジャケット画像" %>
-  </div>
+  <!-- Spotifyプレーヤー -->
+  <% if journal.spotify_track_id.present? %>
+    <div class="mb-6">
+      <iframe style="border-radius:12px" 
+        src="https://open.spotify.com/embed/track/<%= journal.spotify_track_id %>?utm_source=generator" 
+        width="100%"
+        height="352"
+        frameBorder="0" 
+        allowfullscreen="" 
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
+        loading="lazy"
+        class="w-full">
+      </iframe>
+    </div>
+  <% else %>
+    <!-- ジャケット画像（Spotifyプレーヤーがない場合のフォールバック） -->
+    <div class="mb-6">
+      <%= image_tag journal.album_image.presence || 'no-image.png',
+          class: "w-full max-w-2xl mx-auto aspect-square object-cover rounded-lg",
+          alt: "アルバムジャケット画像" %>
+    </div>
+  <% end %>
 
   <!-- 曲情報 -->
-  <div class="space-y-2 mb-4">
-    <div class="flex items-center gap-2 text-sm text-gray-600">
-      <span class="w-5 flex-shrink-0">🎤</span>
+  <div class="space-y-3 mb-6">
+    <div class="flex items-center gap-3 text-base">
+      <span class="w-6 flex-shrink-0">🎤</span>
       <span class="truncate"><%= journal.artist_name %></span>
     </div>
-    <div class="flex items-center gap-2 text-sm text-gray-600">
-      <span class="w-5 flex-shrink-0">🎵</span>
+    <div class="flex items-center gap-3 text-base">
+      <span class="w-6 flex-shrink-0">🎵</span>
       <span class="truncate"><%= journal.song_name %></span>
     </div>
   </div>
 
   <!-- タグ -->
-  <div class="flex flex-wrap gap-2 mb-4">
-    <div class="inline-flex items-center px-3 py-1 bg-red-500 text-white rounded-full text-xs min-w-[80px] justify-center">
+  <div class="flex flex-wrap gap-3 mb-6">
+    <div class="inline-flex items-center px-4 py-2 bg-red-500 text-white rounded-full text-sm">
       <%= journal.emotion %>
     </div>
     <% if journal.genre.present? %>
-      <div class="inline-flex items-center px-3 py-1 bg-blue-500 text-white rounded-full text-xs min-w-[80px] justify-center">
+      <div class="inline-flex items-center px-4 py-2 bg-blue-500 text-white rounded-full text-sm">
         <%= t("activerecord.attributes.journal.genre.#{journal.genre}") %>
       </div>
-      <div class="inline-flex items-center px-3 py-1 bg-green-500 text-white rounded-full text-xs min-w-[80px] justify-center">
-      <%= journal.created_at.strftime("%m/%d %H:%M") %>
+      <div class="inline-flex items-center px-4 py-2 bg-green-500 text-white rounded-full text-sm">
+        <%= journal.created_at.strftime("%m/%d %H:%M") %>
       </div>
     <% end %>
   </div>
 
   <!-- アクションボタン -->
-  <div class="mt-auto space-y-2">
+  <div class="flex gap-3">
     <% if user_signed_in? && journal.user == current_user %>
-      <div class="flex gap-2">
-        <%= link_to '詳細', journal_path(journal), data: { turbo: false },
-            class: "flex-1 text-center py-2 px-4 bg-gray-500 text-white text-sm rounded hover:bg-gray-600 min-w-[120px]" %>
-        <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },
-            class: "flex-1 text-center py-2 px-4 bg-yellow-500 text-white text-sm rounded hover:bg-yellow-600 min-w-[120px]" %>
-        <%= button_to journal_path(journal),
-            method: :delete,
-            data: { turbo: false, confirm: "本当に削除しますか？" },
-            class: "flex-1" do %>
-          <button type="submit" class="w-full text-center py-2 px-4 bg-red-500 text-white text-sm rounded hover:bg-red-600 min-w-[120px]">
-            削除
-          </button>
-        <% end %>
-      </div>
+      <%= link_to '詳細', journal_path(journal), data: { turbo: false },
+          class: "flex-1 text-center py-3 px-6 bg-gray-500 text-white text-base rounded hover:bg-gray-600" %>
+      <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },
+          class: "flex-1 text-center py-3 px-6 bg-yellow-500 text-white text-base rounded hover:bg-yellow-600" %>
+      <%= button_to journal_path(journal),
+          method: :delete,
+          data: { turbo: false, confirm: "本当に削除しますか？" },
+          class: "flex-1" do %>
+        <button type="submit" class="w-full text-center py-3 px-6 bg-red-500 text-white text-base rounded hover:bg-red-600">
+          削除
+        </button>
+      <% end %>
     <% else %>
-      <div class="flex gap-2">
-        <%= link_to '詳細', journal_path(journal), data: { turbo: false },
-            class: "flex-1 text-center py-2 px-4 bg-gray-500 text-white text-sm rounded hover:bg-gray-600 min-w-[120px]" %>
-        <% if user_signed_in? %>
-          <%= render 'journals/favorite_button', journal: journal %>
-        <% else %>
-          <%= link_to new_user_session_path,
-              class: "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-gray-300 text-white text-sm rounded min-w-[120px]" do %>
-            <i class="far fa-heart"></i>
-            <span><%= journal.favorites.count %></span>
-          <% end %>
+      <%= link_to '詳細', journal_path(journal), data: { turbo: false },
+          class: "flex-1 text-center py-3 px-6 bg-gray-500 text-white text-base rounded hover:bg-gray-600" %>
+      <% if user_signed_in? %>
+        <%= render 'journals/favorite_button', journal: journal %>
+      <% else %>
+        <%= link_to new_user_session_path,
+            class: "flex-1 flex items-center justify-center gap-3 py-3 px-6 bg-gray-300 text-white text-base rounded" do %>
+          <i class="far fa-heart"></i>
+          <span><%= journal.favorites.count %></span>
         <% end %>
-      </div>
+      <% end %>
     <% end %>
   </div>
 </div>

--- a/app/views/journals/edit.html.erb
+++ b/app/views/journals/edit.html.erb
@@ -21,6 +21,14 @@
         <div class="bg-gray-100 p-4 text-center mt-6 rounded-lg shadow-inner">
           <h2 class="text-xl font-bold text-gray-800 mb-4">🎵 選択した曲情報</h2>
 
+        <% if @journal.song_name.present? %>
+          <div class="mb-2">
+            <span id="selected-song-name" class="block text-lg font-medium text-gray-800">
+              🎵 曲名: <%= @journal.song_name %>
+            </span>
+          </div>
+        <% end %>
+
           <% if @journal.artist_name.present? %>
             <div class="mb-2">
               <span id="selected-artist-name" class="block text-lg font-medium text-gray-800">
@@ -29,23 +37,21 @@
             </div>
           <% end %>
           
-          <% if @journal.song_name.present? %>
-            <div class="mb-2">
-              <span id="selected-song-name" class="block text-lg font-medium text-gray-800">
-                🎵 曲名: <%= @journal.song_name %>
-              </span>
-            </div>
-          <% end %>
 
-          <% if @journal.album_image.present? %>
-            <div class="mb-4">
-              <a href="https://open.spotify.com/track/<%= @journal.spotify_track_id %>" target="_blank">
-                <img id="selected-album-image" src="<%= @journal.album_image %>" 
-                     alt="アルバム画像" 
-                     class="w-64 h-64 object-cover mx-auto rounded-lg shadow-md">
-              </a>
-            </div>
-          <% end %>
+           <% if @journal.spotify_track_id.present? %>
+              <div class="mb-4">
+                <iframe style="border-radius:12px" 
+                        src="https://open.spotify.com/embed/track/<%= @journal.spotify_track_id %>" 
+                        width="100%"
+                        height="352"
+                        frameBorder="0" 
+                        allowfullscreen="" 
+                        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
+                        loading="lazy"
+                        class="w-full rounded-lg">
+                </iframe>
+              </div>
+            <% end %>
 
           <!-- ジャンル選択 -->
           <div class="mb-4">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,5 +1,5 @@
 <div class="min-h-screen bg-customblue text-black flex flex-col items-center pt-8 pb-8">
-  <div class="bg-white p-6 rounded shadow-md w-full max-w-7xl">
+  <div class="bg-white p-6 rounded shadow-md w-full max-w-[1400px]">
     <!-- ページタイトルと絞り込み -->
     <div class="flex justify-between items-center mb-6">
       <h1 class="text-2xl font-bold">
@@ -48,46 +48,13 @@
     </div>
 
     <!-- 一覧表示 -->
-    <ul class="grid grid-cols-2 gap-4">
-      <% @journals.each_with_index do |journal, index| %>
-        <li class="bg-gray-100 p-4 rounded shadow">
-          <div class="flex items-center space-x-4">
-            <!-- ジャケット写真 -->
-            <div class="w-40 h-40 flex-shrink-0">
-              <%= image_tag(journal.album_image.presence || 'no-image.png',
-                  class: "w-full h-full object-cover rounded-md", 
-                  loading: "lazy",
-                  alt: "アルバムジャケット画像"
-              ) %>
-            </div>
-
-            <!-- 日記情報 -->
-            <div class="flex-grow">
-              <div class="text-lg font-bold mb-2">タイトル: <%= journal.title.presence || "未設定" %></div>
-              <div class="text-sm text-gray-600 space-y-1">
-                <div>作成日: <%= journal.created_at.in_time_zone('Asia/Tokyo').strftime("%Y年%m月%d日 %H:%M") %></div>
-                <div>感情: <%= journal.emotion.presence || "未設定" %></div>
-                <div>ジャンル: <%= journal.genre.present? ? t("activerecord.attributes.journal.genre.#{journal.genre}") : "未設定" %></div>
-                <div>アーティスト名: <%= journal.artist_name.presence || "未設定" %></div>
-                <div>曲名: <%= journal.song_name.presence || "未設定" %></div>
-              </div>
-            </div>
-
-            <!-- ボタングループ -->
-            <div class="flex flex-col gap-2">
-              <%= link_to '日記を見る', journal_path(journal), 
-                  class: "w-28 px-4 py-2 bg-gray-500 text-white font-medium rounded shadow-md hover:bg-gray-600 text-center text-sm" %>
-              <%= link_to "編集", edit_journal_path(journal), 
-                  class: "w-28 px-4 py-2 bg-yellow-500 text-white font-medium rounded shadow-md hover:bg-yellow-600 text-center text-sm" %>
-              <%= button_to "削除", journal_path(journal), 
-                  method: :delete, 
-                  data: { confirm: "本当に削除しますか？" }, 
-                  class: "w-28 px-4 py-2 bg-red-500 text-white font-medium rounded shadow-md hover:bg-red-600 text-sm" %>
-            </div>
-          </div>
-        </li>
+    <div class="space-y-6">
+      <% @journals.each do |journal| %>
+        <div class="w-full">
+          <%= render 'journal_card', journal: journal %>
+        </div>
       <% end %>
-    </ul>
+    </div>
 
     <!-- ページネーション -->
     <div class="mt-6">

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,10 +1,11 @@
 <div class="min-h-screen bg-customblue text-black flex flex-col items-center pt-8 pb-8">
   <div class="bg-white p-6 rounded shadow-md w-full max-w-[1400px]">
-    <!-- ページタイトルと絞り込み -->
+    <!-- ヘッダー部分 -->
     <div class="flex justify-between items-center mb-6">
-      <h1 class="text-2xl font-bold">
-        <%= "#{current_user.name}'s Journal" %>
-      </h1>
+      <div>
+        <h1 class="text-2xl font-bold"><%= "#{current_user.name}'s Journal" %></h1>
+        <p class="text-sm text-gray-600 mt-1">*ジャンルは選択した曲から自動的に設定されます。</p>
+      </div>
       <div class="flex items-center gap-2">
         <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "sort-filter-form" do |f| %>
           <%= f.select :sort,
@@ -47,24 +48,41 @@
       </div>
     </div>
 
-    <!-- 一覧表示 -->
-    <div class="space-y-6">
+    <!-- 日記カード一覧 -->
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-[1400px] mx-auto">
       <% @journals.each do |journal| %>
-        <div class="w-full">
-          <%= render 'journal_card', journal: journal %>
+        <div class="h-full w-full">
+          <%= render 'journals/journal_card', journal: journal %>
         </div>
       <% end %>
     </div>
 
     <!-- ページネーション -->
-    <div class="mt-6">
-      <%= paginate @journals %>
+    <div class="mt-6 flex justify-center">
+      <div class="flex items-center gap-2">
+        <%= paginate @journals, window: 2,
+            outer_window: 1,
+            class: "flex items-center gap-2",
+            previous_label: '前へ',
+            next_label: '次へ' %>
+      </div>
     </div>
 
-     <!-- 新規作成ボタン -->
+    <!-- 新規作成ボタン -->
     <div class="mt-6">
-      <%= link_to "新しい日記を作成", new_journal_path, 
+      <%= link_to "新しい日記を作成", new_journal_path(from: "top"), 
           class: "w-full block text-center py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors" %>
+    </div>
+
+    <!-- Spotifyロゴ -->
+    <div class="mt-8 text-center">
+      <p class="text-sm text-gray-600 mb-2">Powered by</p>
+      <%= link_to "https://developer.spotify.com", target: "_blank", rel: "noopener noreferrer" do %>
+        <%= image_tag "spotify_logo.png", 
+            alt: "Spotify", 
+            class: "h-8 inline-block",
+            style: "max-width: 140px;" %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -76,7 +76,6 @@
 
     <!-- Spotifyロゴ -->
     <div class="mt-8 text-center">
-      <p class="text-sm text-gray-600 mb-2">Powered by</p>
       <%= link_to "https://developer.spotify.com", target: "_blank", rel: "noopener noreferrer" do %>
         <%= image_tag "spotify_logo.png", 
             alt: "Spotify", 

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -48,16 +48,16 @@
           <% end %>
           <% if @journal.album_image.present? %>
             <div class="mb-4">
-            <iframe style="border-radius:12px" 
-                    src="https://open.spotify.com/embed/track/<%= @journal.spotify_track_id %>" 
-                    width="100%"
-                    height="352"
-                    frameBorder="0" 
-                    allowfullscreen="" 
-                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
-                    loading="lazy"
-                    class="w-full rounded-lg">
-            </iframe>
+              <iframe style="border-radius:12px" 
+                      src="https://open.spotify.com/embed/track/<%= @journal.spotify_track_id %>" 
+                      width="100%"
+                      height="352"
+                      frameBorder="0" 
+                      allowfullscreen="" 
+                      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
+                      loading="lazy"
+                      class="w-full rounded-lg">
+              </iframe>
             </div>
           <% end %>
 

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -38,7 +38,7 @@
             </span>
           </div>
 
-          <% if @journal.artist_name.present? %>
+          <% if @journal.spotify_track_id.present? %>
             <div class="mb-2">
               <span id="selected-artist-name" class="block text-lg font-medium text-gray-800">
                 🎤 アーティスト: <%= @journal.artist_name %>

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -19,14 +19,23 @@
 
       <!-- 🎼 曲情報 -->
       <div class="bg-gray-100 p-4 text-center mt-6 rounded-lg shadow-inner">
-        <div class="text-xl font-bold text-gray-800 mb-4 flex items-center justify-center gap-2">
-          <%= image_tag 'spotify.png', alt: 'Spotify Logo', class: 'inline h-6 w-6' %>
-          Spotify曲検索
-        </div>
+        <% unless @journal.song_name.present? || @journal.artist_name.present? || @journal.album_image.present? %>
+          <div class="text-xl font-bold text-gray-800 mb-4 flex items-center justify-center gap-2">
+            <%= image_tag 'spotify.png', alt: 'Spotify Logo', class: 'inline h-6 w-6' %>
+            Spotify曲検索
+          </div>
+        <% end %>
 
         <% if @journal.song_name.present? || @journal.artist_name.present? || @journal.album_image.present? %>
           <div class="text-xl font-bold text-gray-800 mb-4">
             🎵 選択した曲情報
+          </div>
+
+          <% if @journal.song_name.present? %>
+          <div class="mb-2">
+            <span id="selected-song-name" class="block text-lg font-medium text-gray-800">
+              🎵 曲名: <%= @journal.song_name %>
+            </span>
           </div>
 
           <% if @journal.artist_name.present? %>
@@ -36,20 +45,19 @@
               </span>
             </div>
           <% end %>
-          <% if @journal.song_name.present? %>
-            <div class="mb-2">
-              <span id="selected-song-name" class="block text-lg font-medium text-gray-800">
-                🎵 曲名: <%= @journal.song_name %>
-              </span>
-            </div>
           <% end %>
           <% if @journal.album_image.present? %>
             <div class="mb-4">
-              <a href="https://open.spotify.com/track/<%= @journal.spotify_track_id %>" target="_blank">
-                <img id="selected-album-image" src="<%= @journal.album_image %>" 
-                     alt="アルバム画像" 
-                     class="w-64 h-64 object-cover mx-auto rounded-lg shadow-md">
-              </a>
+            <iframe style="border-radius:12px" 
+                    src="https://open.spotify.com/embed/track/<%= @journal.spotify_track_id %>" 
+                    width="100%"
+                    height="352"
+                    frameBorder="0" 
+                    allowfullscreen="" 
+                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
+                    loading="lazy"
+                    class="w-full rounded-lg">
+            </iframe>
             </div>
           <% end %>
 

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -13,46 +13,37 @@
     </div>
 
     <!-- 🎵 曲情報（選択後のみ表示） -->
-    <% if @journal.song_name.present? || @journal.artist_name.present? || @journal.album_image.present? %>
+    <% if @journal.song_name.present? || @journal.artist_name.present? || @journal.spotify_track_id.present? %>
       <div class="bg-gray-100 p-6 text-center rounded-lg shadow-inner space-y-4">
         <h2 class="text-xl font-bold text-gray-800 mb-4">🎵 選択した曲情報</h2>
+
+        <% if @journal.song_name.present? %>
+          <p class="text-lg font-medium text-gray-800">
+            🎼 曲名: <%= @journal.song_name %>
+          </p>
+      <% end %>
+      
         
         <% if @journal.artist_name.present? %>
           <p class="text-lg font-medium text-gray-800">
             🎤 アーティスト: <%= @journal.artist_name %>
           </p>
         <% end %>
-        
-        <% if @journal.song_name.present? %>
-          <p class="text-lg font-medium text-gray-800">
-            🎼 曲名: <%= @journal.song_name %>
-          </p>
-        <% end %>
-        
-        <% if @journal.album_image.present? %>
-          <div class="text-center">
-            <a href="https://open.spotify.com/track/<%= @journal.spotify_track_id %>" target="_blank">
-              <img src="<%= @journal.album_image %>" alt="アルバム画像" class="w-64 h-64 object-cover mx-auto rounded-lg shadow-md">
-            </a>
+      
+        <% if @journal.spotify_track_id.present? %>
+          <div class="mb-4">
+            <iframe style="border-radius:12px" 
+                    src="https://open.spotify.com/embed/track/<%= @journal.spotify_track_id %>" 
+                    width="100%"
+                    height="352"
+                    frameBorder="0" 
+                    allowfullscreen="" 
+                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
+                    loading="lazy"
+                    class="w-full rounded-lg">
+            </iframe>
           </div>
         <% end %>
-        
-        <% if @journal.preview_url.present? %>
-          <div>
-            <audio controls class="w-full rounded-lg">
-              <source src="<%= @journal.preview_url %>" type="audio/mpeg">
-              お使いのブラウザは音声プレビューをサポートしていません。
-            </audio>
-          </div>
-        <% end %>
-        
-        <!-- 🌐 Spotifyリンク -->
-        <div class="flex items-center justify-center mt-4 gap-2">
-          <a href="https://open.spotify.com/track/<%= @journal.spotify_track_id %>" target="_blank" class="flex items-center gap-2 text-green-500 hover:text-green-400">
-            <%= image_tag 'spotify_logo.png', alt: 'Spotifyロゴ', class: 'h-6 w-auto' %>
-            <span class="text-sm font-medium underline">Spotifyで聴く</span>
-          </a>
-        </div>
       </div>
     <% end %>
 

--- a/app/views/journals/timeline.html.erb
+++ b/app/views/journals/timeline.html.erb
@@ -76,7 +76,6 @@
 
     <!-- Spotifyロゴ -->
     <div class="mt-8 text-center">
-      <p class="text-sm text-gray-600 mb-2">Powered by</p>
       <%= link_to "https://developer.spotify.com", target: "_blank", rel: "noopener noreferrer" do %>
         <%= image_tag "spotify_logo.png", 
             alt: "Spotify", 

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -1,54 +1,61 @@
 <!-- 📊 検索結果エリア -->
-<div class="text-xl font-bold text-white text-center flex items-center justify-center gap-2">
-  <%= image_tag 'spotify.png', alt: 'Spotify Logo', class: 'inline h-6 w-6' %>
-  検索結果
-</div>
-
-<% if @tracks.present? %>
-  <div class="p-6 rounded-lg bg-gray-800 shadow-md">
-    <ul class="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <% @tracks.each do |track| %>
-        <li class="p-4 border border-gray-600 rounded-lg bg-gray-700 flex flex-col items-center text-center shadow-md hover:bg-gray-600 transition">
-          <!-- 🎼 曲情報 -->
-          <div class="mb-4">
-            <p class="text-lg font-medium text-white mb-1">🎵 <strong>曲名:</strong> <%= track[:song_name] %></p>
-            <p class="text-sm text-gray-300 mb-2">🎤 <strong>アーティスト:</strong> <%= track[:artist_name] %></p>
-            <% if track[:preview_url].present? %>
-              <p>
-                <a href="<%= track[:preview_url] %>" target="_blank" class="text-blue-400 hover:underline">
-                  🌐 曲を聴く
-                </a>
-              </p>
-            <% end %>
-          </div>
-          <!-- 🎵 アルバム画像 -->
-          <% if track[:album_image].present? %>
-            <div class="w-48 h-48 mb-4">
-              <img src="<%= track[:album_image] %>" alt="アルバム画像" class="w-full h-full object-cover rounded-md shadow-md">
-            </div>
-          <% end %>
-          <!-- 🔊 試聴プレイヤー -->
-          <% if track[:preview_url].present? %>
-            <div class="w-full mb-4">
-              <audio controls class="w-full">
-                <source src="<%= track[:preview_url] %>" type="audio/mpeg">
-              </audio>
-            </div>
-          <% end %>
-
-          <!-- 🎯 曲選択ボタン -->
-          <div>
-            <%= button_to "🎯 この曲を選択", select_tracks_path(selected_track: track.to_json), method: :post, remote: true, class: "px-4 py-2 bg-blue-500 text-white font-medium rounded-md hover:bg-blue-600 transition text-center" %>
-          </div>
-        </li>
-      <% end %>
-    </ul>
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+  <div class="text-xl font-bold text-white text-center flex items-center justify-center gap-2 mb-8">
+    <%= image_tag 'spotify.png', alt: 'Spotify Logo', class: 'inline h-6 w-6' %>
+    検索結果
   </div>
-<% else %>
-  <p class="text-white text-center">🔍 検索結果が見つかりませんでした。</p>
-<% end %>
 
-<!-- 🔄 検索フォーム -->
-<div class="mt-8 p-6 rounded-lg bg-gray-800 shadow-md">
-  <%= render partial: 'spotify/search' %>
+  <% if @tracks.present? %>
+    <!-- 🎵 検索結果一覧 -->
+    <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden">
+      <div class="p-6">
+        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <% @tracks.each do |track| %>
+            <li class="bg-gray-700 rounded-lg shadow-md overflow-hidden">
+              <!-- 🎼 Spotify Player -->
+              <div class="w-full">
+                <iframe style="border-radius:12px" 
+                        src="https://open.spotify.com/embed/track/<%= track[:spotify_track_id] %>" 
+                        width="100%" 
+                        height="152" 
+                        frameBorder="0" 
+                        allowfullscreen="" 
+                        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
+                        loading="lazy">
+                </iframe>
+              </div>
+
+              <!-- 🎯 曲選択ボタン -->
+              <div class="p-4">
+                <%= button_to "🎯 この曲を選択", 
+                    select_tracks_path(
+                      selected_track: {
+                        song_name: track[:song_name],
+                        artist_name: track[:artist_name],
+                        album_image: track[:album_image],
+                        preview_url: track[:preview_url],
+                        spotify_track_id: track[:spotify_track_id],
+                        spotify_url: track[:spotify_url]
+                      }.to_json
+                    ), 
+                    method: :post, 
+                    class: "w-full px-4 py-2 bg-blue-500 text-white font-medium rounded-md hover:bg-blue-600 transition text-center" %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  <% else %>
+    <div class="bg-gray-800 rounded-lg shadow-lg p-8 text-center">
+      <p class="text-white text-lg">🔍 検索結果が見つかりませんでした。</p>
+    </div>
+  <% end %>
+
+  <!-- 🔄 検索フォーム -->
+  <div class="mt-8">
+    <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden">
+      <%= render partial: 'spotify/search' %>
+    </div>
+  </div>
 </div>

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -35,14 +35,14 @@
             </div>
 
             <!-- 曲情報 -->
-            <div class="space-y-2 mb-4">
-              <div class="flex items-center gap-2 text-sm text-gray-600">
-                <span class="w-5 flex-shrink-0">🎵</span>
-                <span class="truncate"><%= track[:song_name] %></span>
+            <div class="space-y-3">
+              <div class="flex items-center gap-2">
+                <span class="w-6 flex-shrink-0 text-xl">🎵</span>
+                <span class="text-lg font-bold truncate"><%= track[:song_name] %></span>
               </div>
-              <div class="flex items-center gap-2 text-sm text-gray-600">
-                <span class="w-5 flex-shrink-0">🎤</span>
-                <span class="truncate"><%= track[:artist_name] %></span>
+              <div class="flex items-center gap-2">
+                <span class="w-6 flex-shrink-0 text-xl">🎤</span>
+                <span class="text-lg font-medium truncate"><%= track[:artist_name] %></span>
               </div>
             </div>
 

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -1,61 +1,112 @@
-<!-- 📊 検索結果エリア -->
-<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-  <div class="text-xl font-bold text-white text-center flex items-center justify-center gap-2 mb-8">
-    <%= image_tag 'spotify.png', alt: 'Spotify Logo', class: 'inline h-6 w-6' %>
-    検索結果
-  </div>
+<div class="min-h-screen bg-customblue text-black flex flex-col items-center pt-8 pb-8">
+  <div class="bg-white p-6 rounded shadow-md w-full max-w-7xl">
+    <!-- ページタイトル -->
+    <div class="flex justify-between items-center mb-6">
+      <h1 class="text-2xl font-bold flex items-center gap-2">
+        <%= image_tag 'spotify.png', alt: 'Spotify Logo', class: 'h-8 w-8' %>
+        検索結果
+      </h1>
+    </div>
 
-  <% if @tracks.present? %>
-    <!-- 🎵 検索結果一覧 -->
-    <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden">
-      <div class="p-6">
-        <ul class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          <% @tracks.each do |track| %>
-            <li class="bg-gray-700 rounded-lg shadow-md overflow-hidden">
-              <!-- 🎼 Spotify Player -->
-              <div class="w-full">
-                <iframe style="border-radius:12px" 
-                        src="https://open.spotify.com/embed/track/<%= track[:spotify_track_id] %>" 
-                        width="100%" 
-                        height="152" 
-                        frameBorder="0" 
-                        allowfullscreen="" 
-                        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
-                        loading="lazy">
-                </iframe>
-              </div>
+    <% if @tracks.present? %>
+      <!-- 検索結果数の表示 -->
+      <% if @total_count&.positive? %>
+        <div class="text-gray-600 text-sm mb-4">
+          全<%= @total_count %>件中 <%= @tracks.offset_value + 1 %>-<%= @tracks.offset_value + @tracks.count %>件を表示
+        </div>
+      <% end %>
 
-              <!-- 🎯 曲選択ボタン -->
-              <div class="p-4">
-                <%= button_to "🎯 この曲を選択", 
-                    select_tracks_path(
-                      selected_track: {
-                        song_name: track[:song_name],
-                        artist_name: track[:artist_name],
-                        album_image: track[:album_image],
-                        preview_url: track[:preview_url],
-                        spotify_track_id: track[:spotify_track_id],
-                        spotify_url: track[:spotify_url]
-                      }.to_json
-                    ), 
-                    method: :post, 
-                    class: "w-full px-4 py-2 bg-blue-500 text-white font-medium rounded-md hover:bg-blue-600 transition text-center" %>
+      <!-- 検索結果一覧 -->
+      <div class="grid grid-cols-2 gap-4">
+        <% @tracks.each do |track| %>
+          <div class="bg-gray-300 rounded-lg shadow h-full flex flex-col p-4">
+            <!-- Spotify Player -->
+            <div class="relative mb-4">
+              <iframe style="border-radius:12px" 
+                      src="https://open.spotify.com/embed/track/<%= track[:spotify_track_id] %>" 
+                      width="100%"
+                      height="352"
+                      frameBorder="0" 
+                      allowfullscreen="" 
+                      allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
+                      loading="lazy"
+                      class="w-full rounded-lg">
+              </iframe>
+            </div>
+
+            <!-- 曲情報 -->
+            <div class="space-y-2 mb-4">
+              <div class="flex items-center gap-2 text-sm text-gray-600">
+                <span class="w-5 flex-shrink-0">🎵</span>
+                <span class="truncate"><%= track[:song_name] %></span>
               </div>
-            </li>
-          <% end %>
-        </ul>
+              <div class="flex items-center gap-2 text-sm text-gray-600">
+                <span class="w-5 flex-shrink-0">🎤</span>
+                <span class="truncate"><%= track[:artist_name] %></span>
+              </div>
+            </div>
+
+            <!-- アクションボタン -->
+            <div class="mt-auto">
+              <%= button_to select_tracks_path(
+                    selected_track: {
+                      song_name: track[:song_name],
+                      artist_name: track[:artist_name],
+                      album_image: track[:album_image],
+                      preview_url: track[:preview_url],
+                      spotify_track_id: track[:spotify_track_id],
+                      spotify_url: track[:spotify_url]
+                    }.to_json
+                  ), 
+                  method: :post, 
+                  class: "w-full" do %>
+                <button type="submit" class="w-full text-center py-2 px-4 bg-gray-500 text-white text-sm rounded hover:bg-gray-600">
+                  選択
+                </button>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
       </div>
-    </div>
-  <% else %>
-    <div class="bg-gray-800 rounded-lg shadow-lg p-8 text-center">
-      <p class="text-white text-lg">🔍 検索結果が見つかりませんでした。</p>
-    </div>
-  <% end %>
 
-  <!-- 🔄 検索フォーム -->
-  <div class="mt-8">
-    <div class="bg-gray-800 rounded-lg shadow-lg overflow-hidden">
-      <%= render partial: 'spotify/search' %>
+      <!-- ページネーション -->
+      <% if @tracks.total_pages > 1 %>
+        <div class="mt-6">
+          <%= paginate @tracks %>
+        </div>
+      <% end %>
+    <% else %>
+      <div class="bg-gray-100 p-8 rounded shadow text-center">
+        <p class="text-gray-600 text-lg">検索結果が見つかりませんでした。</p>
+      </div>
+    <% end %>
+
+    <!-- 再検索フォーム -->
+    <div class="mt-6">
+      <div class="bg-gray-300 rounded-lg shadow p-4">
+        <%= render partial: 'spotify/search' %>
+      </div>
     </div>
   </div>
 </div>
+
+<style>
+  .pagination {
+    @apply flex justify-center gap-2;
+  }
+  .pagination span {
+    @apply inline-block;
+  }
+  .pagination .page {
+    @apply px-4 py-2 bg-gray-500 text-white font-medium rounded shadow-md hover:bg-gray-600 text-center text-sm;
+  }
+  .pagination .page.current {
+    @apply bg-customred;
+  }
+  .pagination .prev, .pagination .next {
+    @apply px-4 py-2 bg-gray-500 text-white font-medium rounded shadow-md hover:bg-gray-600 text-center text-sm;
+  }
+  .pagination .gap {
+    @apply px-2 text-gray-600;
+  }
+</style>

--- a/app/views/static_pages/_main_content.html.erb
+++ b/app/views/static_pages/_main_content.html.erb
@@ -1,9 +1,9 @@
 <div>
     <%= image_tag 'top.png',class: "relative"  %>
-    <div class="bg-customblue text-customred font-bold py-8 px-4 rounded-full w-96 text-center text-4xl absolute top-[75%] left-[5rem] left-2">
+    <div class="bg-customblue text-customred font-bold py-8 px-4 rounded-full w-96 text-center text-4xl absolute top-[65%] left-[5rem] left-2">
         <%= link_to "日記を書く".html_safe, new_journal_path(from: 'top') %>
     </div>
-    <div class="bg-customblue text-customred font-bold py-8 px-4 rounded-full w-96 text-center text-4xl absolute top-[90%] left-[5rem] left-2">
+    <div class="bg-customblue text-customred font-bold py-8 px-4 rounded-full w-96 text-center text-4xl absolute top-[80%] left-[5rem] left-2">
         <%= link_to "過去の日記一覧".html_safe, journals_path %>
     </div>
 </div>


### PR DESCRIPTION
# 🎵 Spotifyプレーヤーの導入とUI改善

## 変更内容
### Spotifyプレーヤーの導入
- アルバム画像、プレビュー、リンクをSpotify埋め込みプレーヤーに置き換え
- プレーヤーのサイズを最適化し、視聴性を向上
- spotify_track_idを各ビューで適切に処理するように修正

### レイアウトの改善
- indexとtimelineページのレイアウトを統一
- グリッドレイアウトを導入（レスポンシブ対応）
  - モバイル：1カラム
  - タブレット：2カラム
  - デスクトップ：3カラム
- カードデザインの改善
  - パディングとマージンの調整
  - テキストカラーの統一
  - フォントサイズの最適化

### コード品質の向上
- 不要なコードの削除（spotify_url等）
- パーシャルの参照方法を統一
- コメントの追加と整理

## 動作確認項目
- [ ] 新規作成時にSpotifyプレーヤーが正しく表示される
- [ ] 編集時にSpotifyプレーヤーが正しく表示される
- [ ] 詳細表示時にSpotifyプレーヤーが正しく表示される
- [ ] タイムラインでSpotifyプレーヤーが正しく表示される
- [ ] インデックスページでSpotifyプレーヤーが正しく表示される
- [ ] レスポンシブデザインが正しく機能する
- [ ] 既存の機能（絞り込み、ソート等）が正常に動作する
## その他
- マイグレーション不要
- 既存のデータは影響を受けない（spotify_track_idがない場合は従来通りアルバム画像を表示）