### PR TITLE
ジャンル選択の検証とエラーメッセージの改善

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -108,10 +108,11 @@ class JournalsController < ApplicationController
       session.delete(:selected_track)
       session.delete(:journal_form)
 
-      redirect_to @journal, notice: "日記を保存しました。"
+      redirect_to @journal, notice: "日記を作成しました"
     else
-      Rails.logger.error "Journal save failed: #{@journal.errors.full_messages}"
-      flash.now[:alert] = "日記の保存に失敗しました。"
+      # エラーメッセージを個別に設定（属性名を除く）
+      error_messages = @journal.errors.map(&:message)
+      flash.now[:alert] = error_messages.join('、')
       render :new, status: :unprocessable_entity
     end
   end
@@ -145,7 +146,9 @@ class JournalsController < ApplicationController
       Rails.logger.info "📍 Redirecting to: #{redirect_path}"
       redirect_to redirect_path
     else
-      flash.now[:alert] = "更新に失敗しました"
+      # エラーメッセージを個別に設定（属性名を除く）
+      error_messages = @journal.errors.map(&:message)
+      flash.now[:alert] = error_messages.join('、')
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -112,7 +112,7 @@ class JournalsController < ApplicationController
     else
       # エラーメッセージを個別に設定（属性名を除く）
       error_messages = @journal.errors.map(&:message)
-      flash.now[:alert] = error_messages.join('、')
+      flash.now[:alert] = error_messages.join("、")
       render :new, status: :unprocessable_entity
     end
   end
@@ -148,7 +148,7 @@ class JournalsController < ApplicationController
     else
       # エラーメッセージを個別に設定（属性名を除く）
       error_messages = @journal.errors.map(&:message)
-      flash.now[:alert] = error_messages.join('、')
+      flash.now[:alert] = error_messages.join("、")
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -14,28 +14,19 @@ class Journal < ApplicationRecord
   validates :artist_name, presence: true, length: { maximum: 100 }
   validates :album_image, presence: true, format: { with: URI.regexp(%w[http https]), message: "must be a valid URL" }
   validates :preview_url, format: { with: URI.regexp(%w[http https]), message: "must be a valid URL" }, allow_blank: true
+  validates :genre, presence: true # 必須
 
   # 列挙型
   enum genre: {
-    j_pop: "j-pop",
-    k_pop: "k-pop",
-    western: "western",
-    anime: "anime",
-    vocaloid: "vocaloid",
-    others: "others"
+    j_pop: 0,
+    k_pop: 1,
+    western: 2,
+    anime: 3,
+    vocaloid: 4,
+    others: 5
   }
 
   enum emotion: [ :喜, :怒, :哀, :楽 ]
-
-  # ジャンルの表示名と値のマッピング
-  MAIN_GENRES = {
-    "j-pop" => "J-POP",
-    "k-pop" => "K-POP",
-    "western" => "洋楽",
-    "anime" => "アニメ/特撮",
-    "vocaloid" => "ボーカロイド",
-    "others" => "その他"
-  }.freeze
 
   # スコープ定義
   scope :by_emotion, ->(emotion) { where(emotion: emotion) if emotion.present? }
@@ -45,16 +36,12 @@ class Journal < ApplicationRecord
     favorites.exists?(user_id: user.id)
   end
 
-  # ジャンルの表示名
-  def genre_display_name
-    case genre
-    when "j-pop" then "J-POP"
-    when "k-pop" then "K-POP"
-    when "western" then "洋楽"
-    when "anime" then "アニメ/特撮"
-    when "vocaloid" then "ボーカロイド"
-    when "others", nil then "その他"
-    end
+  def self.genre_name(genre_key)
+    I18n.t("genres.#{genre_key}")
+  end
+
+  def genre_name
+    self.class.genre_name(genre)
   end
 
   # 既存のジャンルを新しい体系に移行

--- a/app/views/journals/_favorite_button.html.erb
+++ b/app/views/journals/_favorite_button.html.erb
@@ -1,15 +1,23 @@
 <%= turbo_frame_tag "favorite_button_#{journal.id}" do %>
-  <% if journal.favorited_by?(current_user) %>
-    <%= button_to journal_favorites_path(journal), method: :delete,
-        class: "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-pink-500 text-white text-sm rounded hover:bg-pink-600 min-w-[120px]",
-        data: { turbo_stream: true } do %>
-      <i class="fas fa-heart"></i>
-      <span><%= journal.favorites.count %></span>
+  <% if current_user %>
+    <% if journal.favorited_by?(current_user) %>
+      <%= button_to journal_favorites_path(journal), method: :delete,
+          class: "flex-1 flex items-center justify-center gap-2 py-3 px-6 bg-pink-500 text-white text-base rounded hover:bg-pink-600",
+          data: { turbo_stream: true } do %>
+        <i class="fas fa-heart"></i>
+        <span><%= journal.favorites.count %></span>
+      <% end %>
+    <% else %>
+      <%= button_to journal_favorites_path(journal), method: :post,
+          class: "flex-1 flex items-center justify-center gap-2 py-3 px-6 bg-green-500 text-white text-base rounded hover:bg-green-600",
+          data: { turbo_stream: true } do %>
+        <i class="far fa-heart"></i>
+        <span><%= journal.favorites.count %></span>
+      <% end %>
     <% end %>
   <% else %>
-    <%= button_to journal_favorites_path(journal),
-        class: "flex-1 flex items-center justify-center gap-2 py-2 px-4 bg-green-500 text-white text-sm rounded hover:bg-green-600 min-w-[120px]",
-        data: { turbo_stream: true } do %>
+    <%= link_to new_user_session_path,
+        class: "flex-1 flex items-center justify-center gap-2 py-3 px-6 bg-gray-300 text-white text-base rounded" do %>
       <i class="far fa-heart"></i>
       <span><%= journal.favorites.count %></span>
     <% end %>

--- a/app/views/journals/edit.html.erb
+++ b/app/views/journals/edit.html.erb
@@ -13,7 +13,12 @@
       <!-- 📝 タイトル入力 -->
       <div>
         <%= form.label :title, "日記タイトル", class: "block text-xl font-medium text-gray-700 mb-2" %>
-        <%= form.text_field :title, required: true, placeholder: "タイトルを入力", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400",id: "journal-title" %>
+        <%= form.text_field :title, required: true, placeholder: "タイトルを入力", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 #{'border-red-500' if @journal.errors[:title].present?}", id: "journal-title" %>
+        <% if @journal.errors[:title].present? %>
+          <p class="mt-1 text-sm text-red-600">
+            <%= @journal.errors[:title].join(', ') %>
+          </p>
+        <% end %>
       </div>
 
       <!-- 🎼 曲情報（選択後のみ表示） -->
@@ -58,12 +63,17 @@
             <div class="form-group">
               <%= form.label :genre, "ジャンル", class: "block text-md font-medium text-gray-700 mb-2" %>
               <%= form.select :genre, 
-                Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+                Journal.genres.keys.map { |k| [t("genres.#{k}"), k] },
                 { include_blank: '選択してください' },
                 { 
-                  class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 #{'border-red-500' if @journal.errors[:genre].present?}"
                 }
               %>
+              <% if @journal.errors[:genre].present? %>
+                <p class="mt-1 text-sm text-red-600">
+                  <%= @journal.errors[:genre].join(', ') %>
+                </p>
+              <% end %>
             </div>
           </div>
 
@@ -96,13 +106,23 @@
         <%= form.select :emotion, 
             Journal.emotions.map { |k, v| [k, k] }, 
             { prompt: "選択してください" }, 
-            class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400",id: "journal-emotion" %>
+            class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 #{'border-red-500' if @journal.errors[:emotion].present?}", id: "journal-emotion" %>
+        <% if @journal.errors[:emotion].present? %>
+          <p class="mt-1 text-sm text-red-600">
+            <%= @journal.errors[:emotion].join(', ') %>
+          </p>
+        <% end %>
       </div>
 
       <!-- 📝 メモ入力 -->
       <div>
         <%= form.label :content, "本文", class: "block text-md font-medium text-gray-700 mb-2" %>
-        <%= form.text_area :content, required: true, placeholder: "今日の出来事や気持ちを記入", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400",id: "journal-content" %>
+        <%= form.text_area :content, required: true, placeholder: "今日の出来事や気持ちを記入", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 #{'border-red-500' if @journal.errors[:content].present?}", id: "journal-content" %>
+        <% if @journal.errors[:content].present? %>
+          <p class="mt-1 text-sm text-red-600">
+            <%= @journal.errors[:content].join(', ') %>
+          </p>
+        <% end %>
       </div>
 
       <!-- 公開設定 -->

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -69,7 +69,8 @@
           <span>✏️ 編集</span>
         <% end %>
         
-        <%= link_to "https://twitter.com/share?url=#{CGI.escape(journal_url(@journal))}", 
+        <% share_text = "#{@journal.song_name} - #{@journal.artist_name} #MySongJournal" %>
+        <%= link_to "https://twitter.com/share?text=#{CGI.escape(share_text)}&url=#{CGI.escape(journal_url(@journal))}", 
             target: '_blank', 
             class: "px-4 py-2 bg-black text-white font-medium rounded-md hover:bg-gray-800 transition flex items-center",
             rel: "nofollow",

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,8 @@ ja:
       title: "利用規約"
       date_of_enactment: "2025年1月14日 制定"
   activerecord:
+    models:
+      journal: "日記"
     attributes:
       profile:
         name: "名前"
@@ -18,13 +20,28 @@ ja:
         avatar: "アバター画像"
         update: "更新"
       journal:
-        genre:
-          j_pop: "J-POP"
-          k_pop: "K-POP"
-          western: "洋楽"
-          anime: "アニメ/特撮"
-          vocaloid: "ボーカロイド"
-          others: "その他"
+        genre: "ジャンル"
+    errors:
+      models:
+        journal:
+          attributes:
+            genre:
+              blank: "ジャンルを選択してください"
+            title:
+              blank: "タイトルを入力してください"
+            content:
+              blank: "内容を入力してください"
+            song_name:
+              blank: "曲名を入力してください"
+            artist_name:
+              blank: "アーティスト名を入力してください"
+  genres:
+    j_pop: "JPOP"
+    k_pop: "KPOP"
+    western: "洋楽"
+    anime: "アニメ/特撮"
+    vocaloid: "ボーカロイド"
+    others: "その他"
   time:
     formats:
       long: "%Y年%m月%d日 %H:%M"


### PR DESCRIPTION
# 概要
ジャンル選択の検証とエラーメッセージの表示方法を改善しました。

## 変更内容
1. ジャンルのバリデーション
- ジャンルを必須項目として設定
- enumの定義を数値ベースに変更（文字列から整数へ）

2. エラーメッセージの改善
- 各フィールドの下に個別のエラーメッセージを表示
- エラー時にフィールドの枠を赤く表示
- i18nを使用して日本語のエラーメッセージを追加

3. お気に入りボタンの修正
- ログイン状態に応じた表示を修正
- ボタンのスタイルを統一

4. その他の改善
- Twitter共有テキストを復元（曲名とアーティスト名を含める）
- フラッシュメッセージを個別のエラー内容に変更

## 動作確認項目
- [ ] ジャンル未選択時にエラーメッセージが表示される
- [ ] 各フィールドのエラーメッセージが適切に表示される
- [ ] お気に入りボタンが正しく機能する
- [ ] Twitter共有が正しく動作する