### PR TITLE
OGPの最適化（キャッシュ周りとセキュリティ）

### DIFF
--- a/app/controllers/concerns/ogp/meta_tags_handler.rb
+++ b/app/controllers/concerns/ogp/meta_tags_handler.rb
@@ -14,15 +14,14 @@ module Ogp
     end
 
     def generate_ogp_image_url(journal)
-      cache_key = "#{journal.id}-#{journal.updated_at.to_i}"
+      cache_key = journal.updated_at.to_i.to_s
 
       url_for(
         controller: :images,
         action: :ogp,
         text: "#{journal.song_name} - #{journal.artist_name}",
         album_image: journal.album_image,
-        v: cache_key,
-        journal_id: journal.id
+        v: cache_key
       )
     end
   end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -27,7 +27,16 @@ class ImagesController < ApplicationController
       Rails.logger.info "Parsed song name: #{song_name.inspect}"
       Rails.logger.info "Parsed artist name: #{artist_name.inspect}"
 
-      cache_key = "ogp/#{Digest::MD5.hexdigest([song_name, artist_name, params[:album_image]].join('_'))}"
+      # 曲名とアーティスト名を正規化
+      normalized_song_name = song_name.to_s.strip.downcase
+      normalized_artist_name = artist_name.to_s.strip.downcase
+
+      # アルバム画像のURLを正規化
+      normalized_album_image = params[:album_image].to_s.split('?').first
+
+      # キャッシュキーを生成
+      cache_key = "ogp/#{Digest::MD5.hexdigest([normalized_song_name, normalized_artist_name, normalized_album_image].join('_'))}"
+
       Rails.logger.info "Cache key: #{cache_key}"
       
       image_data = Rails.cache.fetch(cache_key, expires_in: 1.week) do

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -2,8 +2,8 @@ class ImagesController < ApplicationController
   include Ogp::ImageGenerator
 
   skip_before_action :authenticate_user!, raise: false
-  skip_before_action :verify_authenticity_token, only: [ :ogp ]
-  before_action :set_cors_headers, only: [ :ogp ]
+  skip_before_action :verify_authenticity_token, only: [:ogp]
+  before_action :set_cors_headers, only: [:ogp]
 
   def ogp
     Rails.logger.info "OGP Request Parameters: #{params.inspect}"
@@ -11,57 +11,23 @@ class ImagesController < ApplicationController
 
     begin
       # パラメータの取得と整形
-      text = params[:text].to_s
-      parts = text.split(" - ").map(&:strip)
-      
-      # 曲名とアーティスト名を正しく抽出
-      song_name = parts[0]
-      artist_name = if parts.size > 2
-        # "曲名 - From xxx - アーティスト名" のパターン
-        parts.last
-      else
-        # "曲名 - アーティスト名" のパターン
-        parts[1]
-      end
-
-      Rails.logger.info "Parsed song name: #{song_name.inspect}"
-      Rails.logger.info "Parsed artist name: #{artist_name.inspect}"
-
-      # 曲名とアーティスト名を正規化
-      normalized_song_name = song_name.to_s.strip.downcase
-      normalized_artist_name = artist_name.to_s.strip.downcase
-
-      # アルバム画像のURLを正規化
-      normalized_album_image = params[:album_image].to_s.split('?').first
+      song_name, artist_name = parse_text(params[:text])
+      album_image = normalize_album_image(params[:album_image])
 
       # キャッシュキーを生成
-      cache_key = "ogp/#{Digest::MD5.hexdigest([normalized_song_name, normalized_artist_name, normalized_album_image].join('_'))}"
-
+      cache_key = generate_cache_key(song_name, artist_name, album_image)
       Rails.logger.info "Cache key: #{cache_key}"
-      
-      image_data = Rails.cache.fetch(cache_key, expires_in: 1.week) do
-        Rails.logger.info "Cache miss - Generating new OGP image"
-        Rails.logger.info "Generating OGP image for song: #{song_name}, artist: #{artist_name}"
 
-        # 画像生成とバイナリデータへの変換を一度に行う
-        image = generate_ogp_image(
-          album_image: params[:album_image],
-          song_name: song_name,
-          artist_name: artist_name
-        )
-        
-        Rails.logger.info "Image generated successfully, converting to blob"
-        blob = image.to_blob
-        image.destroy!
-        blob
+      # キャッシュから画像データを取得または生成
+      image_data = Rails.cache.fetch(cache_key, expires_in: 1.year) do
+        Rails.logger.info "Cache miss - Generating new OGP image"
+        generate_ogp_image_blob(song_name, artist_name, album_image)
       end
 
       Rails.logger.info "Image data size: #{image_data.bytesize} bytes"
 
       # レスポンスヘッダーの設定
-      response.headers["Content-Type"] = "image/png"
-      response.headers["Cache-Control"] = "public, max-age=31536000"
-      response.headers["ETag"] = %("#{Digest::MD5.hexdigest(image_data)}")
+      set_response_headers(image_data)
 
       # 条件付きGETのチェック
       if stale?(etag: response.headers["ETag"])
@@ -71,19 +37,87 @@ class ImagesController < ApplicationController
         Rails.logger.info "304 Not Modified response sent"
       end
     rescue StandardError => e
-      Rails.logger.error "OGP画像生成エラー: #{e.message}"
-      Rails.logger.error "Backtrace: #{e.backtrace.join("\n")}"
-      Rails.logger.error "Parameters: #{params.inspect}"
-      
-      # デフォルトのOGP画像を返す
-      default_ogp_path = Rails.root.join("app/assets/images/ogp.png")
-      Rails.logger.info "Sending default OGP image: #{default_ogp_path}"
-      send_file default_ogp_path, type: "image/png", disposition: "inline"
+      handle_error(e)
     end
   end
 
   private
 
+  # パラメータから曲名とアーティスト名を抽出
+  def parse_text(text)
+    parts = text.to_s.split(" - ").map(&:strip)
+    song_name = parts[0]
+    artist_name = parts.size > 2 ? parts.last : parts[1]
+    Rails.logger.info "Parsed song name: #{song_name.inspect}"
+    Rails.logger.info "Parsed artist name: #{artist_name.inspect}"
+    [song_name.to_s.strip.downcase, artist_name.to_s.strip.downcase]
+  end
+
+  # アルバム画像URLを正規化
+  def normalize_album_image(album_image)
+    normalized_url = album_image.to_s.split('?').first
+    valid_url?(normalized_url) ? normalized_url : nil
+  end
+
+  # キャッシュキーを生成
+  def generate_cache_key(song_name, artist_name, album_image)
+    Digest::MD5.hexdigest([song_name, artist_name, album_image].join('_'))
+  end
+
+  # OGP画像を生成し、バイナリデータを返す
+  def generate_ogp_image_blob(song_name, artist_name, album_image)
+    image = generate_ogp_image(
+      album_image: album_image,
+      song_name: song_name,
+      artist_name: artist_name
+    )
+    blob = image.to_blob
+    image.destroy!
+    blob
+  end
+
+  # レスポンスヘッダーを設定
+  def set_response_headers(image_data)
+    response.headers["Content-Type"] = "image/png"
+    response.headers["Cache-Control"] = "public, max-age=31536000"
+    response.headers["ETag"] = %("#{Digest::MD5.hexdigest(image_data)}")
+  end
+
+  # エラー時の処理
+  def handle_error(error)
+    Rails.logger.error "OGP画像生成エラー: #{error.message}"
+    Rails.logger.error "Backtrace: #{error.backtrace.join("\n")}"
+    Rails.logger.error "Parameters: #{params.inspect}"
+
+    # デフォルトのOGP画像を返す
+    default_ogp_path = Rails.root.join("app/assets/images/ogp.png")
+    Rails.logger.info "Sending default OGP image: #{default_ogp_path}"
+    send_file default_ogp_path, type: "image/png", disposition: "inline"
+  end
+
+  # 外部URLの検証
+  def valid_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTP) && !uri.host.nil?
+  rescue URI::InvalidURIError
+    false
+  end
+
+  # CORSヘッダーを設定
+  def set_cors_headers
+    allowed_origins = ENV.fetch("ALLOWED_ORIGINS", "").split(",")
+
+    if allowed_origins.include?(request.headers["Origin"])
+      response.headers["Access-Control-Allow-Origin"] = request.headers["Origin"]
+    end
+
+    response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
+    response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept"
+    response.headers["Cache-Control"] = "public, max-age=31536000"
+    response.headers["Expires"] = 1.year.from_now.httpdate
+  end
+
+  # OGP画像を生成
   def generate_ogp_image(album_image:, song_name:, artist_name:)
     Rails.logger.info "Starting OGP image generation"
     start_time = Time.current
@@ -98,12 +132,12 @@ class ImagesController < ApplicationController
       c.fill "#333333"
       c.gravity "North"
       c.pointsize 48
-      c.draw "text 0,40 '#{song_name}'"
+      c.draw "text 0,40 '#{song_name.truncate(25, separator: /\s/)}'"
       c.pointsize 36
-      c.draw "text 0,110 '#{artist_name}'"
+      c.draw "text 0,110 '#{artist_name.truncate(20, separator: /\s/)}'"
     end
 
-    # アルバムアート
+    # アルバムアートを追加
     if album_image.present?
       begin
         album_art = MiniMagick::Image.open(album_image)
@@ -118,7 +152,7 @@ class ImagesController < ApplicationController
       end
     end
 
-    # フッター
+    # フッターを追加
     image.combine_options do |c|
       c.font font_path
       c.fill "#333333"
@@ -131,25 +165,5 @@ class ImagesController < ApplicationController
 
     Rails.logger.info "OGP image generation completed in #{Time.current - start_time} seconds"
     image
-  end
-
-  def set_cors_headers
-    allowed_origins = [
-      "https://ogp.buta3.net",
-      "https://cards-dev.twitter.com",
-      "https://twitter.com",
-      "https://x.com",
-      "https://www.facebook.com",
-      "https://l.facebook.com"
-    ]
-
-    if allowed_origins.include?(request.headers["Origin"])
-      response.headers["Access-Control-Allow-Origin"] = request.headers["Origin"]
-    end
-
-    response.headers["Access-Control-Allow-Methods"] = "GET, HEAD, OPTIONS"
-    response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept"
-    response.headers["Cache-Control"] = "public, max-age=31536000"
-    response.headers["Expires"] = 1.year.from_now.httpdate
   end
 end

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -11,9 +11,21 @@ class ImagesController < ApplicationController
 
     begin
       # パラメータの取得と整形
-      text_parts = params[:text].to_s.split(" - ")
-      song_name = text_parts[0]
-      artist_name = text_parts[1]
+      text = params[:text].to_s
+      parts = text.split(" - ").map(&:strip)
+      
+      # 曲名とアーティスト名を正しく抽出
+      song_name = parts[0]
+      artist_name = if parts.size > 2
+        # "曲名 - From xxx - アーティスト名" のパターン
+        parts.last
+      else
+        # "曲名 - アーティスト名" のパターン
+        parts[1]
+      end
+
+      Rails.logger.info "Parsed song name: #{song_name.inspect}"
+      Rails.logger.info "Parsed artist name: #{artist_name.inspect}"
 
       cache_key = "ogp/#{Digest::MD5.hexdigest([song_name, artist_name, params[:album_image]].join('_'))}"
       Rails.logger.info "Cache key: #{cache_key}"

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -25,7 +25,10 @@ class ImagesController < ApplicationController
     rescue StandardError => e
       Rails.logger.error "OGP画像生成エラー: #{e.message}"
       Rails.logger.error e.backtrace.join("\n")
-      head :internal_server_error
+      
+      # デフォルトのOGP画像を返す
+      default_ogp_path = Rails.root.join("app/assets/images/ogp.png")
+      send_file default_ogp_path, type: "image/png", disposition: "inline"
     end
   end
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -2,8 +2,8 @@ class ImagesController < ApplicationController
   include Ogp::ImageGenerator
 
   skip_before_action :authenticate_user!, raise: false
-  skip_before_action :verify_authenticity_token, only: [:ogp]
-  before_action :set_cors_headers, only: [:ogp]
+  skip_before_action :verify_authenticity_token, only: [ :ogp ]
+  before_action :set_cors_headers, only: [ :ogp ]
 
   def ogp
     Rails.logger.info "OGP Request Parameters: #{params.inspect}"
@@ -50,18 +50,18 @@ class ImagesController < ApplicationController
     artist_name = parts.size > 2 ? parts.last : parts[1]
     Rails.logger.info "Parsed song name: #{song_name.inspect}"
     Rails.logger.info "Parsed artist name: #{artist_name.inspect}"
-    [song_name.to_s.strip.downcase, artist_name.to_s.strip.downcase]
+    [ song_name.to_s.strip.downcase, artist_name.to_s.strip.downcase ]
   end
 
   # アルバム画像URLを正規化
   def normalize_album_image(album_image)
-    normalized_url = album_image.to_s.split('?').first
+    normalized_url = album_image.to_s.split("?").first
     valid_url?(normalized_url) ? normalized_url : nil
   end
 
   # キャッシュキーを生成
   def generate_cache_key(song_name, artist_name, album_image)
-    Digest::MD5.hexdigest([song_name, artist_name, album_image].join('_'))
+    Digest::MD5.hexdigest([ song_name, artist_name, album_image ].join("_"))
   end
 
   # OGP画像を生成し、バイナリデータを返す

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -19,14 +19,14 @@
 
         <% if @journal.song_name.present? %>
           <p class="text-lg font-medium text-gray-800">
-            🎼 曲名: <%= @journal.song_name %>
+            🎼 曲名: <%= truncate(@journal.song_name, length: 25) %>
           </p>
       <% end %>
       
         
         <% if @journal.artist_name.present? %>
           <p class="text-lg font-medium text-gray-800">
-            🎤 アーティスト: <%= @journal.artist_name %>
+            🎤 アーティスト: <%= truncate(@journal.artist_name, length: 20) %>
           </p>
         <% end %>
       

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -116,8 +116,19 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts << "mysongjournal.com"
   config.hosts << "mysongjournal.onrender.com" # Renderのホストも許可する
-  # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.hosts << "og.nullnull.dev"  # OGP用のドメイン
+
+  # OGPクローラーからのアクセスを許可
+  config.host_authorization = {
+    exclude: ->(request) {
+      request.path.start_with?("/images/ogp") ||
+      request.user_agent&.include?("Twitterbot") ||
+      request.user_agent&.include?("facebookexternalhit") ||
+      request.user_agent&.include?("LinkedInBot") ||
+      request.user_agent&.include?("LINE-Parts")
+    }
+  }
+
   config.time_zone = "UTC"
   config.active_record.default_timezone = :utc
 end

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,0 +1,8 @@
+Rails.application.config.app_domain = case Rails.env
+when 'production'
+  'mysongjournal.com'  # 本番環境のドメイン
+when 'staging'
+  'staging.mysongjournal.com'  # ステージング環境のドメイン
+else
+  'localhost:3000'  # 開発環境のドメイン
+end

--- a/config/initializers/app_config.rb
+++ b/config/initializers/app_config.rb
@@ -1,8 +1,8 @@
 Rails.application.config.app_domain = case Rails.env
-when 'production'
-  'mysongjournal.com'  # 本番環境のドメイン
-when 'staging'
-  'staging.mysongjournal.com'  # ステージング環境のドメイン
+when "production"
+  "mysongjournal.com"  # 本番環境のドメイン
+when "staging"
+  "staging.mysongjournal.com"  # ステージング環境のドメイン
 else
-  'localhost:3000'  # 開発環境のドメイン
+  "localhost:3000"  # 開発環境のドメイン
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,14 +18,7 @@ Rails.application.routes.draw do
   end
 
   # OGP画像のルーティング
-  get "images/ogp.png", to: "images#ogp"
-
-  # OGP画像用のルートを追加
-  resources :images do
-    collection do
-      get :ogp
-    end
-  end
+  get "images/ogp", to: "images#ogp", format: :png
 
   # お問い合わせフォーム
   resources :contacts, only: [ :new, :create ]

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -9,12 +9,27 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     # generate_ogp_imageメソッドをスタブ化
     ImagesController.any_instance.stubs(:generate_ogp_image).returns(dummy_response)
 
-    get ogp_images_path, params: {
+    get "/images/ogp.png", params: {
       album_image: "https://example.com/image.jpg",
-      text: "テストタイトル"
+      text: "テストタイトル - テストアーティスト"
     }
 
     assert_response :success
+    assert_equal "image/png", response.content_type
+  end
+
+  test "should handle missing parameters" do
+    get "/images/ogp.png"
+    assert_response :success  # デフォルト画像が返されるはず
+    assert_equal "image/png", response.content_type
+  end
+
+  test "should handle invalid album image url" do
+    get "/images/ogp.png", params: {
+      album_image: "invalid-url",
+      text: "テストタイトル - テストアーティスト"
+    }
+    assert_response :success  # デフォルト画像が返されるはず
     assert_equal "image/png", response.content_type
   end
 end

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -5,6 +5,7 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
     # 最小限のモック
     dummy_response = mock()
     dummy_response.stubs(:to_blob).returns("dummy image data")
+    dummy_response.stubs(:destroy!).returns(true)  # destroy!メソッドを追加
 
     # generate_ogp_imageメソッドをスタブ化
     ImagesController.any_instance.stubs(:generate_ogp_image).returns(dummy_response)
@@ -19,17 +20,31 @@ class ImagesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should handle missing parameters" do
+    # デフォルト画像のモック
+    default_image = mock()
+    default_image.stubs(:to_blob).returns("default image data")
+    default_image.stubs(:destroy!).returns(true)
+
+    ImagesController.any_instance.stubs(:generate_ogp_image).returns(default_image)
+
     get "/images/ogp.png"
-    assert_response :success  # デフォルト画像が返されるはず
+    assert_response :success
     assert_equal "image/png", response.content_type
   end
 
   test "should handle invalid album image url" do
+    # エラー時の画像のモック
+    error_image = mock()
+    error_image.stubs(:to_blob).returns("error image data")
+    error_image.stubs(:destroy!).returns(true)
+
+    ImagesController.any_instance.stubs(:generate_ogp_image).returns(error_image)
+
     get "/images/ogp.png", params: {
       album_image: "invalid-url",
       text: "テストタイトル - テストアーティスト"
     }
-    assert_response :success  # デフォルト画像が返されるはず
+    assert_response :success
     assert_equal "image/png", response.content_type
   end
 end


### PR DESCRIPTION
## 概要
<!-- このプルリクエストで何を実装・修正したのか具体的に記載してください -->
OGP画像生成機能の改善を行い、パフォーマンス向上・セキュリティ強化・SNSクローラー対応を実施しました。

## 変更内容
<!-- 具体的な変更内容や追加した機能について箇条書きで記載 -->
- **最適化**
  - OGP画像生成処理の効率化
  - 画像サイズ・レイアウトの調整（アルバムアート 350x350）
  - テキストの適切な `truncate` 処理（曲名25文字、アーティスト名20文字）
- **キャッシュ機能の追加**
  - `Rails.cache` を使用して画像をキャッシュ
  - キャッシュキーにMD5ハッシュを使用
  - キャッシュ有効期限を1年に設定
- **ルーティングの整理**
  - OGP画像用のルートを統一し、フォーマット指定を追加
  - 変更前:
    ```ruby
    resources :images do
      collection do
        get :ogp
      end
    end
    ```
  - 変更後:
    ```ruby
    get "images/ogp", to: "images#ogp", format: :png
    ```
- **パフォーマンス改善**
  - 304 Not Modified に対応し、不要なリクエストを削減
  - ETag の追加によるレスポンス最適化
- **セキュリティ強化**
  - CORSヘッダーの適切な設定
  - 許可するオリジンの明示的な指定
    ```ruby
    allowed_origins = [
      "https://ogp.buta3.net",
      "https://cards-dev.twitter.com",
      "https://twitter.com",
      "https://x.com"
    ]
    ```
- **SNSクローラー対応**
  - Twitterbot / Facebook / LinkedIn / LINE のクローラーを許可
    ```ruby
    config.host_authorization = {
      exclude: ->(request) {
        request.path.start_with?("/images/ogp") ||
        request.user_agent&.include?("Twitterbot") ||
        request.user_agent&.include?("LinkedInBot") ||
        request.user_agent&.include?("LINE-Parts")
      }
    }
    ```
- **デバッグ機能の強化**
  - 詳細なログ出力の追加
  - デバッグ用の一時ファイル保存機能
    ```ruby
    temp_path = "/tmp/debug_ogp_#{Time.now.to_i}.png"
    image.write(temp_path)
    Rails.logger.info "Debug: OGP image saved to #{temp_path}"
    ```

## 動作確認方法
<!-- どのように動作確認を行ったか、具体的な手順を記載 -->
1. **OGP画像の生成確認**
   - [ ] 通常の投稿でOGP画像が正しく生成されることを確認
2. **キャッシュ機能の確認**
   - [ ] 同じ画像を取得する際にキャッシュが使用されていることを確認
3. **SNSクローラーの対応確認**
   - [ ] Twitter / Facebook / LINE でシェアしてプレビューが適切に表示されることを確認
4. **テキストの表示確認**
   - [ ] 長いタイトルの投稿で `truncate` 処理が適切に行われることを確認
5. **エラーハンドリングの確認**
   - [ ] 画像生成に失敗した場合、デフォルト画像が表示されることを確認
 
## 備考
- OGP画像生成の影響範囲が広いため、特にSNSクローラーの動作確認を重点的にお願いします。
- キャッシュの影響で変更が即時反映されない場合があるため、キャッシュクリアの手順も併せて確認してください。
