### PR TITLE
空文字とNULLの時はXのユニークネス制約の対象外に

### DIFF
--- a/db/migrate/20250213080119_update_x_link_unique_constraint.rb
+++ b/db/migrate/20250213080119_update_x_link_unique_constraint.rb
@@ -1,0 +1,10 @@
+class UpdateXLinkUniqueConstraint < ActiveRecord::Migration[7.0]
+  def change
+    # 既存のインデックスを削除
+    remove_index :users, :x_link if index_exists?(:users, :x_link)
+    
+    # 空でない値のみユニーク制約を適用
+    add_index :users, :x_link, unique: true, 
+      where: "x_link != '' AND x_link IS NOT NULL"
+  end
+end

--- a/db/migrate/20250213080119_update_x_link_unique_constraint.rb
+++ b/db/migrate/20250213080119_update_x_link_unique_constraint.rb
@@ -2,9 +2,9 @@ class UpdateXLinkUniqueConstraint < ActiveRecord::Migration[7.0]
   def change
     # 既存のインデックスを削除
     remove_index :users, :x_link if index_exists?(:users, :x_link)
-    
+
     # 空でない値のみユニーク制約を適用
-    add_index :users, :x_link, unique: true, 
+    add_index :users, :x_link, unique: true,
       where: "x_link != '' AND x_link IS NOT NULL"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_09_190930) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_13_080119) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -136,7 +136,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_09_190930) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
-    t.index ["x_link"], name: "index_users_on_x_link", unique: true, where: "(x_link IS NOT NULL)"
+    t.index ["x_link"], name: "index_users_on_x_link", unique: true, where: "(((x_link)::text <> ''::text) AND (x_link IS NOT NULL))"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## 概要
- 値が入っていないときもユニークネス制約がかかってしまっていたのを修正
- 空文字とNULLのときはユニーク制約の対象外としました

## 変更内容
- **修正**: 新規マイグレーションファイル(db/migrate/20250213080119_update_x_link_unique_constraint.rb)の追加
-  `where: "x_link != '' AND x_link IS NOT NULL"`の記載を追加

## 備考
- 本番環境で解決していなければやり直し