### PR TITLE
Fix/layout

### DIFF
--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -5,7 +5,10 @@
       <%= journal.title %>
     </h3>
     <div class="flex items-center gap-4 mt-2">
-      <span class="text-base">by <%= journal.user.name %></span>
+      <span class="text-base">by <%= link_to journal.user.name, other_user_path(journal.user) %></span>
+      <%= image_tag journal.user.avatar.presence || 'profile_sample.png',
+          class: "h-12 w-12 rounded-full object-cover mr-4",
+          alt: "プロフィール画像" %>
       <% if user_signed_in? && journal.user != current_user %>
         <%= render 'follows/button', user: journal.user %>
       <% end %>

--- a/app/views/journals/edit.html.erb
+++ b/app/views/journals/edit.html.erb
@@ -12,7 +12,7 @@
 
       <!-- 📝 タイトル入力 -->
       <div>
-        <%= form.label :title, "日記タイトル", class: "block text-xl font-medium text-gray-700 mb-2" %>
+        <%= form.label :title, "日記タイトル", class: "block text-gray-700 text-xl font-bold" %>
         <%= form.text_field :title, required: true, placeholder: "タイトルを入力", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark-mode-text",id: "journal-title" %>
       </div>
 
@@ -56,7 +56,7 @@
           <!-- ジャンル選択 -->
           <div class="mb-4">
             <div class="form-group">
-              <%= form.label :genre, "ジャンル", class: "block text-md font-medium mb-2 text-gray-700" %>
+              <%= form.label :genre, "ジャンル", class: "block text-gray-700 text-xl font-bold" %>
               <%= form.select :genre, 
                 Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
                 { include_blank: '選択してください' },
@@ -92,7 +92,7 @@
 
       <!-- 😊 感情入力 -->
       <div>
-        <%= form.label :emotion, "感情", class: "block dark-mode-text font-medium text-sm font-bold" %>
+        <%= form.label :emotion, "感情", class: "block text-gray-700 text-xl font-bold" %>
         <%= form.select :emotion, 
             Journal.emotions.map { |k, v| [k, k] }, 
             { prompt: "選択してください" }, 
@@ -101,7 +101,7 @@
 
       <!-- 📝 メモ入力 -->
       <div>
-        <%= form.label :content, "本文", class: "block dark-mode-text font-medium text-sm font-bold" %>
+        <%= form.label :content, "本文", class: "block text-gray-700 text-xl font-bold" %>
         <%= form.text_area :content, required: true, placeholder: "今日の出来事や気持ちを記入", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark-mode-text",id: "journal-content" %>
       </div>
 
@@ -109,10 +109,16 @@
       <div class="mb-4">
         <div class="flex items-center">
           <%= form.check_box :public, class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500", style: "transform: scale(1.5);" %>
-          <%= form.label :public, "タイムラインに投稿する", class: "ml-3 block text-gray-700 text-sm font-bold" %>
+          <%= form.label :public, "タイムラインに投稿する", class: "ml-3 block text-gray-700 text-xl font-bold" %>
         </div>
-        <p class="text-sm text-gray-600 mt-1">※チェックを外すと、タイムラインには表示されません</p>
+        <p class="text-md text-gray-700 mt-1 font-bold">※チェックを外すと、タイムラインには表示されません</p>
       </div>
+
+      <% if @journal.spotify_track_id.present? %>
+        <div class="text-center text-red-600 font-bold text-lg mb-4">
+          ⚠️ジャンルの選択も忘れずに！
+        </div>
+      <% end %>
 
 
       <!-- 💾 保存ボタン -->

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -13,7 +13,7 @@
 
       <!-- 📝 タイトル入力 -->
       <div>
-        <%= form.label :title, "日記タイトル", class: "block text-xl font-medium text-black mb-2" %>
+        <%= form.label :title, "日記タイトル", class: "block text-gray-700 text-xl font-bold" %>
         <%= form.text_field :title, required: true, placeholder: "タイトルを入力", name: "journal[title]", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark-mode-text",id: "journal-title" %>
       </div>
 
@@ -64,7 +64,7 @@
          <!-- ジャンル選択 -->
           <div class="mb-4">
             <div class="form-group">
-              <%= form.label :genre, "ジャンル", class: "block text-md font-medium text-black mb-2" %>
+              <%= form.label :genre, "ジャンル", class: "block text-gray-700 text-xl font-bold" %>
               <%= form.select :genre, 
                 Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
                 { include_blank: '選択してください' },
@@ -98,18 +98,16 @@
 
       <!-- 😊 感情入力 -->
       <div>
-        <%= form.label :emotion, "感情", class: "block text-md font-medium text-black mb-2" %>
+        <%= form.label :emotion, "感情", class: "block text-gray-700 text-xl font-bold" %>
         <%= form.select :emotion, 
             Journal.emotions.map { |k, v| [k, k] }, 
             { prompt: "選択してください" }, 
-            name: "journal[emotion]", 
-            class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark-mode-text",
-            id: "journal-emotion" %>
+            class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark-mode-text",id: "journal-emotion" %>
       </div>
 
       <!-- 📝 メモ入力 -->
       <div>
-        <%= form.label :content, "本文", class: "block text-md font-medium text-black mb-2" %>
+        <%= form.label :content, "本文", class: "block text-gray-700 text-xl font-bold" %>
         <%= form.text_area :content, required: true, placeholder: "今日の出来事や気持ちを記入", name: "journal[content]", class: "w-full px-4 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-400 dark-mode-text",id: "journal-content" %>
       </div>
 

--- a/app/views/journals/new.html.erb
+++ b/app/views/journals/new.html.erb
@@ -114,12 +114,17 @@
       <!-- 公開設定 -->
       <div class="mb-4">
         <div class="flex items-center">
-          <%= form.check_box :public, checked: true, class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500", style: "transform: scale(1.5);" %>
-          <%= form.label :public, "タイムラインに投稿する", class: "ml-3 block text-gray-700 text-sm font-bold" %>
+          <%= form.check_box :public, class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500", style: "transform: scale(1.5);" %>
+          <%= form.label :public, "タイムラインに投稿する", class: "ml-3 block text-gray-700 text-xl font-bold" %>
         </div>
-        <p class="text-sm text-gray-600 mt-1">※チェックを外すと、タイムラインには表示されません</p>
+        <p class="text-md text-gray-700 mt-1 font-bold">※チェックを外すと、タイムラインには表示されません</p>
       </div>
 
+      <% if @journal.spotify_track_id.present? %>
+      <div class="text-center text-red-600 font-bold text-lg mb-4">
+        ⚠️ジャンルの選択も忘れずに！
+      </div>
+    <% end %>
 
       <!-- 💾 保存ボタン -->
       <div class="text-center mt-6">


### PR DESCRIPTION
# 概要
- タイムラインにアバター画像を追加し、ユーザーネームをクリックするとプロフィールページに遷移するようにしました。
- フォームのスタイルを統一し、ユーザーインターフェースを改善しました。

# 変更内容
### アバター画像の追加
- タイムラインに表示されるジャーナルカードにユーザーのアバター画像を追加しました。
- アバター画像が設定されていない場合は、デフォルト画像を表示します。

### ユーザーネームのリンク化
- ユーザーネームをクリックすると、そのユーザーのプロフィールページに遷移するようにリンクを追加しました。

### スタイルの統一
- フォームのラベルやテキストのスタイルを統一し、全体のデザインを改善しました。

# 技術的な変更点
## `edit.html.erb`
- 公開設定のラベルと注意書きのスタイルを更新し、ジャンル選択の注意メッセージを追加しました。

```html
<div class="mb-4">
  <div class="flex items-center">
    <%= form.check_box :public, class: "h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500", style: "transform: scale(1.5);" %>
    <%= form.label :public, "タイムラインに投稿する", class: "ml-3 block text-gray-700 text-xl font-bold" %>
  </div>
  <p class="text-md text-gray-700 mt-1 font-bold">※チェックを外すと、タイムラインには表示されません</p>
</div>

<% if @journal.spotify_track_id.present? %>
  <div class="text-center text-red-600 font-bold text-lg mb-4">
    ⚠️ジャンルの選択も忘れずに！
  </div>
<% end %>
```

## `_journal_card.html.erb`
- ユーザーネームをリンク化し、アバター画像を追加しました。

```html
<h3 class="text-lg font-bold text-gray-800">
  <%= journal.title %>
</h3>
<div class="flex items-center gap-4 mt-2">
  <span class="text-base">by <%= link_to journal.user.name, other_user_path(journal.user) %></span>
  <%= image_tag journal.user.avatar.presence || 'profile_sample.png',
      class: "h-12 w-12 rounded-full object-cover mr-4",
      alt: "プロフィール画像" %>
  <% if user_signed_in? && journal.user != current_user %>
    <%= render 'follows/button', user: journal.user %>
  <% end %>
</div>
```

# 動作確認方法
### タイムラインの確認
- [ ] タイムラインページを開き、各ジャーナルカードにアバター画像が表示されていることを確認。
- [ ] ユーザーネームをクリックして、プロフィールページに遷移することを確認。

### フォームのスタイル確認
- [ ] ジャーナル編集ページを開き、フォームのラベルやテキストのスタイルが統一されていることを確認。

# 影響範囲
- タイムライン表示
- ジャーナル編集フォーム
- ユーザープロフィールページへのリンク
