### PR TITLE
お問い合わせ、利用規約、プライバシーポリシーのスマホ対応/スマホ時のヘッダープルダウンの色味変更/target _blankに続いてrel="noopener noreferrerを記載

### DIFF
--- a/app/views/contacts/new.html.erb
+++ b/app/views/contacts/new.html.erb
@@ -2,16 +2,16 @@
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center mb-12">
       <h1 class="text-3xl font-bold text-accent">お問い合わせ</h1>
-      <p class="mt-4 text-gray-600">ご質問やご要望がございましたら、以下のフォームよりお気軽にお問い合わせください。</p>
+      <p class="mt-4 text-gray-600">ご質問やご要望がございましたら、以下のフォームよりお気軽にお問い合わせください。</p>
     </div>
 
-    <div class="bg-white shadow-xl rounded-lg overflow-hidden">
+    <div class="bg-white shadow-xl rounded-lg">
       <div class="grid grid-cols-1 md:grid-cols-2">
         <!-- 左側：イメージセクション -->
         <div class="bg-accent p-8 text-white flex flex-col justify-center items-center">
         <div class="mb-8 flex">
-          <%= image_tag "profile_sample.png", class: "w-64 h-64 object-cover rounded-full mr-4 mb-8" %>
-          <%= image_tag "logo.png", class: "w-64 h-64 object-cover rounded-full ml-4 mb-8" %>
+          <%= image_tag "profile_sample.png", class: "w-32 h-32 sm:w-64 sm:h-64 object-cover rounded-full mr-4 mb-8" %>
+          <%= image_tag "logo.png", class: "w-32 h-32 sm:w-64 sm:h-64 object-cover rounded-full ml-4 mb-8" %>
         </div>
           <div class="text-center">
             <h2 class="text-2xl font-bold mb-4">お気軽にご連絡ください</h2>

--- a/app/views/journals/_selected_song_info.html.erb
+++ b/app/views/journals/_selected_song_info.html.erb
@@ -20,7 +20,7 @@
 
   <% if journal.album_image.present? %>
     <div class="mb-4 text-center">
-      <a href="https://open.spotify.com/track/<%= journal.spotify_track_id %>" target="_blank">
+      <a href="https://open.spotify.com/track/<%= journal.spotify_track_id %>" target="_blank" rel="noopener noreferrer">
         <img id="selected-album-image" src="<%= journal.album_image %>" 
              alt="アルバム画像" 
              class="w-64 h-64 object-cover mx-auto rounded-lg shadow-md">

--- a/app/views/pages/privacy_policy.html.erb
+++ b/app/views/pages/privacy_policy.html.erb
@@ -1,7 +1,7 @@
 <!-- プライバシーポリシーページ -->
 <div class="min-h-screen bg-white py-10 px-4 sm:px-6 lg:px-8">
   <div class="max-w-3xl mx-auto">
-    <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-62">
       <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
     </div>
 

--- a/app/views/pages/terms.html.erb
+++ b/app/views/pages/terms.html.erb
@@ -1,7 +1,7 @@
 <!-- 利用規約ページ -->
 <div class="min-h-screen bg-white py-10 px-4 sm:px-6 lg:px-8">
   <div class="max-w-3xl mx-auto">
-    <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-72">
+    <div class="flex justify-center items-center mt-6 mb-6 mx-62">
       <h1 class="text-3xl font-bold text-accent text-center"><%= t('.title') %></h1>
     </div>
 

--- a/app/views/shared/_header_nav.html.erb
+++ b/app/views/shared/_header_nav.html.erb
@@ -21,8 +21,8 @@
     <!-- Mobile View -->
     <div class="sm:hidden">
       <details class="dropdown relative">
-        <summary class="btn m-1 bg-customred text-white whitespace-nowrap">コンテンツ</summary>
-        <ul class="menu dropdown-content bg-customred text-white rounded-box z-10 w-52 p-2 shadow absolute" style="left: -20px;">
+        <summary class="btn m-1 bg-blue-800 text-white whitespace-nowrap">コンテンツ</summary>
+        <ul class="menu dropdown-content bg-blue-800 text-white rounded-box z-10 w-52 p-2 shadow absolute" style="left: -20px;">
           <li><%= link_to '日記を書く', new_journal_path %></li>
           <li><%= link_to 'タイムライン', timeline_journals_path %></li>
           <li><%= link_to '過去の日記一覧', journals_path %></li>
@@ -43,8 +43,8 @@
     <!-- Mobile View -->
     <div class="sm:hidden">
       <details class="dropdown relative">
-        <summary class="btn m-1 bg-customred text-white whitespace-nowrap">コンテンツ</summary>
-        <ul class="menu dropdown-content bg-customred text-white rounded-box z-10 w-52 p-2 shadow absolute" style="left: -20px;">
+        <summary class="btn m-1 bg-blue-800 text-white whitespace-nowrap">コンテンツ</summary>
+        <ul class="menu dropdown-content bg-blue-800 text-white rounded-box z-10 w-52 p-2 shadow absolute" style="left: -20px;">
           <li><%= link_to 'タイムライン', timeline_journals_path %></li>
           <li><%= link_to 'ログイン', new_user_session_path %></li>
           <li><%= link_to 'サインアップ', new_user_registration_path %></li>

--- a/app/views/shared/_header_nav.html.erb
+++ b/app/views/shared/_header_nav.html.erb
@@ -21,7 +21,7 @@
     <!-- Mobile View -->
     <div class="sm:hidden">
       <details class="dropdown relative">
-        <summary class="btn m-1 bg-blue-800 text-white whitespace-nowrap">コンテンツ</summary>
+        <summary class="btn m-1 bg-blue-700 text-white whitespace-nowrap">コンテンツ</summary>
         <ul class="menu dropdown-content bg-blue-800 text-white rounded-box z-10 w-52 p-2 shadow absolute" style="left: -20px;">
           <li><%= link_to '日記を書く', new_journal_path %></li>
           <li><%= link_to 'タイムライン', timeline_journals_path %></li>
@@ -43,7 +43,7 @@
     <!-- Mobile View -->
     <div class="sm:hidden">
       <details class="dropdown relative">
-        <summary class="btn m-1 bg-blue-800 text-white whitespace-nowrap">コンテンツ</summary>
+        <summary class="btn m-1 bg-blue-700 text-white whitespace-nowrap">コンテンツ</summary>
         <ul class="menu dropdown-content bg-blue-800 text-white rounded-box z-10 w-52 p-2 shadow absolute" style="left: -20px;">
           <li><%= link_to 'タイムライン', timeline_journals_path %></li>
           <li><%= link_to 'ログイン', new_user_session_path %></li>


### PR DESCRIPTION
## 概要
- お問い合わせ、利用規約、プライバシーポリシーのスマホ対応レスポンシブデザイン
- スマホ時のヘッダープルダウンの色味変更
- target _blankに続いてrel="noopener noreferrerを記載

## 変更内容
- **修正**: お問い合わせページの説明文の重複を修正
- **修正**: `app/views/journals/_selected_song_info.html.erb` で `rel="noopener noreferrer"` を追加
- **修正**: `app/views/pages/privacy_policy.html.erb` の `mx-72` を `mx-62` に変更
- **修正**: `app/views/pages/terms.html.erb` の `mx-72` を `mx-62` に変更
- **修正**: `app/views/shared/_header_nav.html.erb` のモバイルビューのボタン色を `bg-customred` から `bg-blue-700` へ変更
- `app/views/journals/contacts.html.erbのレスポンシブデザインでsm:w-64 h-64を追加することで、スマホサイズではw_32 h-32　pcサイズではw-64 h-64にしました

## スクリーンショット
- スマホサイズ
![image](https://github.com/user-attachments/assets/2a6aab18-0a5e-4b51-a91d-fd7f83cbfd44)
