### PR TITLE
曲検索結果ページのレスポンシブデザイン/ページネーションの編集/再検索をアコーディオン化

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -10,7 +10,9 @@
   <nav class="flex justify-center items-center space-x-2 mt-8">
     <% unless current_page.first? %>
       <%= first_page_tag %>
-      <%= prev_page_tag %>
+      <span class="hidden sm:inline">
+        <%= prev_page_tag %>
+      </span>
     <% end %>
 
     <% each_page do |page| -%>
@@ -22,7 +24,9 @@
     <% end -%>
 
     <% unless current_page.last? %>
-      <%= next_page_tag %>
+      <span class="hidden sm:inline">
+        <%= next_page_tag %>
+      </span>
       <%= last_page_tag %>
     <% end %>
   </nav>

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -12,15 +12,16 @@
       <% if @total_count&.positive? %>
         <div class="text-gray-600 text-sm mb-4">
           全<%= @total_count %>件中 <%= @tracks.offset_value + 1 %>-<%= @tracks.offset_value + @tracks.count %>件を表示
+          <br>
           検索条件:
           <span class="text-blue-500 font-bold">
-            <%= query_string.presence || '特になし' %>
+            <%= query_string.presence.truncate(20) || '特になし' %>
           </span>
         </div>
       <% end %>
 
       <!-- 検索結果一覧 -->
-      <div class="grid grid-cols-2 gap-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <% @tracks.each do |track| %>
           <div class="bg-gray-300 rounded-lg shadow h-full flex flex-col p-4">
             <!-- Spotify Player -->
@@ -71,7 +72,7 @@
         <% end %>
       </div>
 
-    <div tabindex="0" class="collapse collapse-plus bg-customblue hover:bg-customblue/90 rounded-lg justify-center items-center">
+    <div tabindex="0" class="collapse collapse-plus bg-customblue hover:bg-customblue/90 rounded-lg justify-center items-center mt-4 mb-4">
       <input type="checkbox" class="peer" /> 
       <div class="collapse-title text-xl font-medium text-white">
         再検索はこちらからどうぞ🎧
@@ -86,7 +87,12 @@
       <!-- ページネーション -->
       <% if @tracks.total_pages > 1 %>
         <div class="mt-6">
-          <%= paginate @tracks %>
+          <div class="hidden sm:block">
+            <%= paginate @tracks %>
+          </div>
+          <div class="sm:hidden">
+            <%= paginate @tracks, window: 1, outer_window: 0 %>
+          </div>
         </div>
       <% end %>
     <% else %>

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -7,10 +7,6 @@
         検索結果
       </h1>
     </div>
-
-    <!-- 検索フォームのパーシャルを追加 -->
-    <%= render 'spotify/search' %>
-
     <% if @tracks.present? %>
       <!-- 検索結果数の表示 -->
       <% if @total_count&.positive? %>
@@ -74,6 +70,18 @@
           </div>
         <% end %>
       </div>
+
+    <div tabindex="0" class="collapse collapse-plus bg-customblue hover:bg-customblue/90 rounded-lg justify-center items-center">
+      <input type="checkbox" class="peer" /> 
+      <div class="collapse-title text-xl font-medium text-white">
+        再検索はこちらからどうぞ🎧
+      </div>
+      <div class="collapse-content bg-customblue text-white"> 
+        <!-- 検索フォームのパーシャルを追加 -->
+        <%= render 'spotify/search' %>
+      </div>
+    </div>
+
 
       <!-- ページネーション -->
       <% if @tracks.total_pages > 1 %>


### PR DESCRIPTION
## 概要
ページネーションと検索結果のUIを改善しました。

## 変更内容
- ページネーションの前後ボタンをレスポンシブ対応
  - モバイルでは `prev_page_tag` と `next_page_tag` をシンプルに表示
  - デスクトップでは `first_page_tag` と `last_page_tag` も表示
- 検索結果一覧の表示をレスポンシブ対応
  - モバイル: 1カラム
  - デスクトップ: 2カラム
- 再検索ボタンを daisyuiの`collapse` コンポーネントで表示しアコーディオンにしました
  - 初期状態では折りたたみ
  - クリックで検索フォームを表示
- ページネーションの表示をデバイスごとに最適化
  - モバイル: `paginate @tracks, window: 1, outer_window: 0`
  - デスクトップ: `paginate @tracks`

## 動作確認方法
1. 楽曲を検索
2. 検索結果がレスポンシブに表示されることを確認
3. 再検索ボタンをクリックし、検索フォームが表示されることを確認
4. ページネーションが適切に表示され、機能することを確認

## スクリーンショット

- アコーディオン

![image](https://github.com/user-attachments/assets/1b5987a2-a90b-440c-9ae6-d8aeb433334d)
