### PR TITLE
再検索フォームの幅を小さくしました

### DIFF
--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -72,7 +72,7 @@
         <% end %>
       </div>
 
-    <div tabindex="0" class="collapse collapse-plus bg-customblue hover:bg-customblue/90 rounded-lg justify-center items-center mt-4 mb-4">
+    <div tabindex="0" class="collapse collapse-plus bg-customblue rounded-lg justify-center items-center mt-4 mb-4 max-w-2xl mx-auto">
       <input type="checkbox" class="peer" /> 
       <div class="collapse-title text-xl font-medium text-white">
         再検索はこちらからどうぞ🎧
@@ -102,4 +102,3 @@
     <% end %>
   </div>
 </div>
-


### PR DESCRIPTION
## 概要
- 再検索フォームの幅が大きすぎたので調整しました

## スクリーンショット
![image](https://github.com/user-attachments/assets/4cb7b133-34c8-4a5d-85ae-38933480f45a)
