### PR TITLE
Spotifyのログインが必要だと思いましたが、現状不要だったので機能だけ作ってコメントアウト/代わりにbrowserでフル再生できない場合は、メッセージを表示するようにしました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,9 +46,8 @@ gem "rest-client"
 
 # Google OAuth2認証用のGem
 gem "omniauth-google-oauth2"
+gem "omniauth-spotify"
 gem "omniauth-rails_csrf_protection"
-
-gem "rspotify"
 gem "dotenv-rails"
 gem "redis"
 gem "sidekiq"
@@ -58,6 +57,9 @@ gem "mini_magick"
 gem "image_processing", "~> 1.2"
 gem "meta-tags", require: "meta_tags"
 gem "aws-sdk-s3"
+
+# ブラウザとデバイスの検出
+gem 'browser'
 
 # Security
 gem "rack-attack"

--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem "meta-tags", require: "meta_tags"
 gem "aws-sdk-s3"
 
 # ブラウザとデバイスの検出
-gem 'browser'
+gem "browser"
 
 # Security
 gem "rack-attack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
       msgpack (~> 1.2)
     brakeman (7.0.0)
       racc
+    browser (6.2.0)
     builder (3.3.0)
     capybara (3.40.0)
       addressable
@@ -288,6 +289,8 @@ GEM
     omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    omniauth-spotify (0.0.13)
+      omniauth-oauth2 (~> 1.1)
     orm_adapter (0.5.0)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -380,10 +383,6 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
-    rspotify (2.12.4)
-      addressable (~> 2.8.0)
-      omniauth-oauth2 (>= 1.6)
-      rest-client (~> 2.0.2)
     rubocop (1.69.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -493,6 +492,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   brakeman
+  browser
   capybara
   cssbundling-rails
   debug
@@ -513,6 +513,7 @@ DEPENDENCIES
   mocha
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  omniauth-spotify
   pg (~> 1.1)
   puma (>= 5.0)
   rack-attack
@@ -520,7 +521,6 @@ DEPENDENCIES
   redis
   rest-client
   rspec-rails
-  rspotify
   rubocop-rails-omakase
   selenium-webdriver
   sidekiq

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   # allow_browser versions: :modern
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  helper_method :browser
+
   protected
 
   def configure_permitted_parameters
@@ -27,5 +29,9 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(resource)
     root_path
+  end
+
+  def browser
+    @browser ||= Browser.new(request.user_agent)
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,6 @@
 # app/controllers/users/omniauth_callbacks_controller.rb
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  skip_before_action :verify_authenticity_token, only: [:google_oauth2, :spotify]
+  skip_before_action :verify_authenticity_token, only: [ :google_oauth2, :spotify ]
 
   def google_oauth2
     callback_for(:google_oauth2)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,9 +1,17 @@
+# app/controllers/users/omniauth_callbacks_controller.rb
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  skip_before_action :verify_authenticity_token, only: :google_oauth2
+  skip_before_action :verify_authenticity_token, only: [:google_oauth2, :spotify]
 
   def google_oauth2
-    callback_for(:google)
+    callback_for(:google_oauth2)
   end
+
+  # 将来的な機能拡張時に使用
+  # def spotify
+  #   callback_for(:spotify)
+  # end
+
+  private
 
   def callback_for(provider)
     @user = User.from_omniauth(request.env["omniauth.auth"])
@@ -13,16 +21,17 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       set_flash_message(:notice, :success, kind: provider.to_s.capitalize) if is_navigational_format?
     else
       Rails.logger.error "OAuth user creation failed: #{@user.errors.full_messages.join(', ')}"
-      flash[:alert] = "Google認証に失敗しました。#{@user.errors.full_messages.join(', ')}"
+      flash[:alert] = "#{provider.to_s.capitalize}認証に失敗しました。#{@user.errors.full_messages.join(', ')}"
       redirect_to new_user_registration_url
     end
   rescue => e
     Rails.logger.error "OAuth error: #{e.message}"
-    flash[:alert] = "認証中にエラーが発生しました"
     redirect_to new_user_registration_url
   end
 
+  protected
+
   def failure
-    redirect_to root_path
+    redirect_to root_path, alert: "認証に失敗しました。もう一度お試しください。"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,9 @@ class User < ApplicationRecord
   has_one :profile
   # Deviseのモジュール
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [ :google_oauth2 ]
+         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [ :google_oauth2, 
+           # :spotify  # 将来的な機能拡張時に使用
+         ]
   # バリデーション
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, uniqueness: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   has_one :profile
   # Deviseのモジュール
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [ :google_oauth2, 
+         :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [ :google_oauth2
            # :spotify  # 将来的な機能拡張時に使用
          ]
   # バリデーション

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -59,6 +59,13 @@
           <img class="h-5 w-5" src="https://www.svgrepo.com/show/475656/google-color.svg" alt="Google logo">
           <span class="ml-2">Googleでログイン</span>
         <% end %>
+        <%# Spotifyログインボタンをコメントアウト %>
+        <%#= link_to user_spotify_omniauth_authorize_path, method: :post, data: { turbo: false }, class: "w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50" do %>
+          <%# <svg class="h-5 w-5" viewBox="0 0 24 24" fill="#1DB954">
+            <%# <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+          <%# </svg>
+          <%# <span class="ml-2">Spotifyでログイン</span>
+        <%# end %>
         <div class="mt-4 flex items-center justify-between">
           <div class="text-sm">
             <%= link_to t("devise.shared.links.sign_up", default: "サインアップ"), new_user_registration_path, class: "font-medium text-indigo-600 hover:text-indigo-500" %>

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -24,10 +24,10 @@
         height="352"
         frameBorder="0" 
         allowfullscreen="" 
-        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
-        loading="lazy"
-        class="w-full">
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture; encrypted-media"
+        loading="lazy">
       </iframe>
+      <%= render 'shared/spotify_fallback', track_id: journal.spotify_track_id %>
     </div>
   <% else %>
     <!-- ジャケット画像（Spotifyプレーヤーがない場合のフォールバック） -->

--- a/app/views/journals/show.html.erb
+++ b/app/views/journals/show.html.erb
@@ -33,15 +33,15 @@
         <% if @journal.spotify_track_id.present? %>
           <div class="mb-4">
             <iframe style="border-radius:12px" 
-                    src="https://open.spotify.com/embed/track/<%= @journal.spotify_track_id %>" 
+                    src="https://open.spotify.com/embed/track/<%= @journal.spotify_track_id %>?utm_source=generator" 
                     width="100%"
                     height="352"
                     frameBorder="0" 
                     allowfullscreen="" 
-                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" 
-                    loading="lazy"
-                    class="w-full rounded-lg">
+                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                    loading="lazy">
             </iframe>
+            <%= render 'shared/spotify_fallback', track_id: @journal.spotify_track_id %>
           </div>
         <% end %>
       </div>

--- a/app/views/shared/_spotify_fallback.html.erb
+++ b/app/views/shared/_spotify_fallback.html.erb
@@ -1,0 +1,19 @@
+<% if browser.safari? || browser.device.mobile? %>
+  <div class="mt-2 p-4 bg-gray-200 rounded-lg">
+    <p class="text-sm text-gray-700 mb-2">💡 フル再生するには：</p>
+    <a href="https://open.spotify.com/track/<%= track_id %>" 
+       target="_blank"
+       rel="noopener noreferrer" 
+       class="inline-flex items-center px-4 py-2 bg-[#1DB954] text-white rounded-full hover:bg-[#1ed760] transition-colors">
+      <span class="mr-2">
+        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
+        </svg>
+      </span>
+      Spotifyアプリで開く
+    </a>
+    <p class="text-xs text-gray-600 mt-2">
+      ※ お使いのブラウザではプレビュー再生のみ対応しています
+    </p>
+  </div>
+<% end %>

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -36,7 +36,8 @@
                       loading="lazy"
                       class="w-full rounded-lg">
               </iframe>
-            </div>
+
+            <%= render 'shared/spotify_fallback', track_id: track[:spotify_track_id] %>
 
             <!-- 曲情報 -->
             <div class="space-y-3">

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -281,7 +281,7 @@ Devise.setup do |config|
                     redirect_uri: ENV["GOOGLE_REDIRECT_URI_PRODUCTION"] || "http://localhost:3000/users/auth/google_oauth2/callback"
                   }
   # config.omniauth :spotify, 　将来的に必要になればコメントを解除
-  #                 ENV['SPOTIFY_CLIENT_ID'], 
+  #                 ENV['SPOTIFY_CLIENT_ID'],
   #                 ENV['SPOTIFY_CLIENT_SECRET'],
   #                 scope: %w(
   #                   user-read-email

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -280,6 +280,18 @@ Devise.setup do |config|
                     scope: "email,profile",
                     redirect_uri: ENV["GOOGLE_REDIRECT_URI_PRODUCTION"] || "http://localhost:3000/users/auth/google_oauth2/callback"
                   }
+  # config.omniauth :spotify, 　将来的に必要になればコメントを解除
+  #                 ENV['SPOTIFY_CLIENT_ID'], 
+  #                 ENV['SPOTIFY_CLIENT_SECRET'],
+  #                 scope: %w(
+  #                   user-read-email
+  #                   playlist-read-private
+  #                   user-read-private
+  #                   streaming
+  #                   user-read-playback-state
+  #                   user-modify-playback-state
+  #                   app-remote-control
+  #                 ).join(' ')
 
   # 本番環境でもGETリクエストを許可
   OmniAuth.config.allowed_request_methods = [ :post, :get ]

--- a/config/initializers/rspotify.rb
+++ b/config/initializers/rspotify.rb
@@ -1,4 +1,0 @@
-# Spotify API認証をテスト環境では無効化
-unless Rails.env.test?
-  RSpotify.authenticate(ENV["SPOTIFY_CLIENT_ID"], ENV["SPOTIFY_CLIENT_SECRET"])
-end


### PR DESCRIPTION
## 概要
フル再生できる時とできない時の違いがspotifyログインに関連してると思い機能を作りましたが、関係なかったのでコメントアウトしました（ゴワゴワを防ぐため）
- 代わりにbrowserというgemを入れブラウザの識別をして、フル再生できない時（現状、モバイルの時とsafariの時は確認）はメッセージが表示されるようにしました。
- 
## スクリーンショット（任意）
  - fallbackのメッセージ
  
![image](https://github.com/user-attachments/assets/5b0a1146-9f52-4c0f-b66c-2d862fb2c47d)
