### PR TITLE
spotifyログインの設定追加（やはり不要になったのでコメントアウト中）、タイムラインと一覧ページのレスポンシブデザイン、ログイン・新規登録ページのレイアウトが崩れてたので修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -3,7 +3,19 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :verify_authenticity_token, only: [ :google_oauth2, :spotify ]
 
   def google_oauth2
-    callback_for(:google_oauth2)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication
+      set_flash_message(:notice, :success, scope: [:devise, :omniauth_callbacks, :google_oauth2]) if is_navigational_format?
+    else
+      Rails.logger.error "OAuth user creation failed: #{@user.errors.full_messages.join(', ')}"
+      set_flash_message(:alert, :failure, scope: [:devise, :omniauth_callbacks, :google_oauth2])
+      redirect_to new_user_registration_url
+    end
+  rescue => e
+    Rails.logger.error "OAuth error: #{e.message}"
+    redirect_to new_user_registration_url
   end
 
   # 将来的な機能拡張時に使用

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
-<div class="flex justify-center items-center bg-customblue min-h-screen py-12 wide-screen">
-  <div class="rounded-lg p-8" style="aspect-ratio: 1 / 1; width: 90%; max-width: 400px;">
+<div class="flex-grow flex justify-center items-center">
+  <div class="rounded-lg p-8 shadow-md" style="width: 90%; max-width: 400px;">
     <%= render "devise/shared/form_layout" do %>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6 h-full" }) do |form| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6" }) do |form| %>
         <!-- Title -->
         <h2 class="text-2xl font-bold text-gray-700 text-center mb-6">
           <%= t('devise.registrations.new.sign_up', default: 'アカウント登録') %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,4 +1,4 @@
-<div class="flex justify-center items-center bg-customblue">
+<div class="flex justify-center items-center bg-customblue min-h-screen py-12 wide-screen">
   <div class="rounded-lg p-8" style="aspect-ratio: 1 / 1; width: 90%; max-width: 400px;">
     <%= render "devise/shared/form_layout" do %>
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-6 h-full" }) do |form| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
-<div class="flex justify-center items-center bg-customblue">
-  <div class="rounded-lg p-8" style="aspect-ratio: 1 / 1; width: 90%; max-width: 400px;">
+<div class="flex-grow flex justify-center items-center">
+  <div class="rounded-lg p-8 shadow-md" style="width: 90%; max-width: 400px;">
     <%= render "devise/shared/form_layout" do %>
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6 h-full" }) do |form| %>
+      <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-6" }) do |form| %>
         <!-- Title -->
         <h2 class="text-2xl font-bold text-gray-700 text-center mb-6">
           <%= t('devise.sessions.new.sign_in', default: 'ログイン') %>

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -6,9 +6,11 @@
     </h3>
     <div class="flex items-center gap-4 mt-2">
       <span class="text-base">by <%= link_to journal.user.name, other_user_path(journal.user) %></span>
-      <%= image_tag journal.user.avatar.presence || 'profile_sample.png',
-          class: "h-12 w-12 rounded-full object-cover mr-4",
-          alt: "プロフィール画像" %>
+      <%= link_to other_user_path(journal.user) do %>
+        <%= image_tag journal.user.avatar.presence || 'profile_sample.png',
+            class: "h-12 w-12 rounded-full object-cover mr-4",
+            alt: "プロフィール画像" %>
+      <% end %>
       <% if user_signed_in? && journal.user != current_user %>
         <%= render 'follows/button', user: journal.user %>
       <% end %>
@@ -51,15 +53,15 @@
   </div>
 
   <!-- タグ -->
-  <div class="flex flex-wrap gap-3 mb-6">
-    <div class="inline-flex items-center px-4 py-2 bg-red-500 text-white rounded-full text-sm">
+  <div class="flex flex-wrap gap-2 md:gap-3 mb-6 items-center justify-center w-full">
+    <div class="inline-flex px-3 md:px-4 py-1 md:py-2 bg-red-500 text-white rounded-full text-sm md:text-sm">
       <%= journal.emotion %>
     </div>
     <% if journal.genre.present? %>
-      <div class="inline-flex items-center px-4 py-2 bg-blue-500 text-white rounded-full text-sm">
+      <div class="inline-flex px-3 md:px-4 py-1 md:py-2 bg-blue-500 text-white rounded-full text-sm md:text-sm">
         <%= t("activerecord.attributes.journal.genre.#{journal.genre}") %>
       </div>
-      <div class="inline-flex items-center px-4 py-2 bg-green-500 text-white rounded-full text-sm">
+      <div class="inline-flex px-3 md:px-4 py-1 md:py-2 bg-green-500 text-white rounded-full text-sm md:text-sm">
         <%= journal.created_at.strftime("%m/%d %H:%M") %>
       </div>
     <% end %>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -1,13 +1,15 @@
 <div class="min-h-screen bg-customblue text-black flex flex-col items-center pt-8 pb-8">
   <div class="bg-white p-6 rounded shadow-md w-full max-w-[1400px]">
     <!-- ヘッダー部分 -->
-    <div class="flex justify-between items-center mb-6">
-      <div>
-        <h1 class="text-2xl font-bold"><%= "#{current_user.name}'s Journal" %></h1>
-        <p class="text-sm text-gray-600 mt-1">*ジャンルは選択した曲から自動的に設定されます。</p>
+    <div class="flex flex-col md:flex-row justify-between items-center mb-6">
+      <div class="w-full md:w-auto text-center md:text-left">
+        <h1 class="text-lg md:text-2xl font-bold"><%= "#{current_user.name}'s Journal" %></h1>
+        <p class="text-sm text-gray-600 mt-2 md:mt-1">*ジャンルは選択した曲から自動的に設定されます。</p>
       </div>
-      <div class="flex items-center gap-2">
-        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "sort-filter-form" do |f| %>
+
+      <!-- PC表示のフィルター -->
+      <div class="hidden md:flex items-center gap-2">
+        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "sort-filter-form-pc" do |f| %>
           <%= f.select :sort,
               [['新しい順', 'desc'], ['古い順', 'asc']],
               { selected: params[:sort] || 'desc' },
@@ -20,7 +22,7 @@
           <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
         <% end %>
 
-        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
+        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form-pc" do |f| %>
           <%= f.select :emotion,
               Journal.emotions.keys.map { |key| [key.humanize, key] },
               { include_blank: "すべての感情", selected: params[:emotion] },
@@ -33,7 +35,7 @@
           <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
         <% end %>
 
-        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "genre-filter-form" do |f| %>
+        <%= form_with url: journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "genre-filter-form-pc" do |f| %>
           <%= f.select :genre,
               Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
               { include_blank: "すべてのジャンル", selected: params[:genre] },
@@ -45,6 +47,50 @@
           <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
           <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
         <% end %>
+      </div>
+
+      <!-- スマホ表示のフィルター -->
+      <div class="md:hidden w-full mt-4">
+        <div class="flex flex-col gap-2">
+          <%= form_with url: journals_path, method: :get, local: true, class: "w-full", id: "sort-filter-form-mobile" do |f| %>
+            <%= f.select :sort,
+                [['新しい順', 'desc'], ['古い順', 'asc']],
+                { selected: params[:sort] || 'desc' },
+                {
+                  class: "w-full px-2 py-1 text-xs border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+            <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+          <% end %>
+
+          <%= form_with url: journals_path, method: :get, local: true, class: "w-full", id: "emotion-filter-form-mobile" do |f| %>
+            <%= f.select :emotion,
+                Journal.emotions.keys.map { |key| [key.humanize, key] },
+                { include_blank: "すべての感情", selected: params[:emotion] },
+                {
+                  class: "w-full px-2 py-1 text-xs border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+            <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+          <% end %>
+
+          <%= form_with url: journals_path, method: :get, local: true, class: "w-full", id: "genre-filter-form-mobile" do |f| %>
+            <%= f.select :genre,
+                Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+                { include_blank: "すべてのジャンル", selected: params[:genre] },
+                {
+                  class: "w-full px-2 py-1 text-xs border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+            <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+          <% end %>
+        </div>
       </div>
     </div>
 

--- a/app/views/journals/timeline.html.erb
+++ b/app/views/journals/timeline.html.erb
@@ -16,45 +16,92 @@
         </p>
       </div>
 
-      <div class="flex flex-wrap items-center justify-center gap-2 w-full">
-        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[30%] min-w-[100px]", id: "sort-filter-form" do |f| %>
-          <%= f.select :sort,
-              [['新しい順', 'desc'], ['古い順', 'asc']],
-              { selected: params[:sort] || 'desc' },
-              {
-                class: "w-full px-2 md:px-4 py-1 md:py-2 text-sm md:text-base border rounded-md bg-customred text-white",
-                onchange: "this.form.requestSubmit()"
-              }
-          %>
-          <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
-          <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
-        <% end %>
+      <!-- PC表示 -->
+      <div class="hidden md:block">
+        <div class="flex justify-center items-center gap-4">
+          <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[150px]", id: "sort-filter-form-pc" do |f| %>
+            <%= f.select :sort,
+                [['新しい順', 'desc'], ['古い順', 'asc']],
+                { selected: params[:sort] || 'desc' },
+                {
+                  class: "w-full px-4 py-2 text-sm border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+            <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+          <% end %>
 
-        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[30%] min-w-[100px]", id: "emotion-filter-form" do |f| %>
-          <%= f.select :emotion,
-              Journal.emotions.keys.map { |key| [key.humanize, key] },
-              { include_blank: "すべての感情", selected: params[:emotion] },
-              {
-                class: "w-full px-2 md:px-4 py-1 md:py-2 text-sm md:text-base border rounded-md bg-customred text-white",
-                onchange: "this.form.requestSubmit()"
-              }
-          %>
-          <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
-          <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
-        <% end %>
+          <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[180px]", id: "emotion-filter-form-pc" do |f| %>
+            <%= f.select :emotion,
+                Journal.emotions.keys.map { |key| [key.humanize, key] },
+                { include_blank: "すべての感情", selected: params[:emotion] },
+                {
+                  class: "w-full px-4 py-2 text-sm border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+            <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+          <% end %>
 
-        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[30%] min-w-[100px]", id: "genre-filter-form" do |f| %>
-          <%= f.select :genre,
-              Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
-              { include_blank: "すべてのジャンル", selected: params[:genre] },
-              {
-                class: "w-full px-2 md:px-4 py-1 md:py-2 text-sm md:text-base border rounded-md bg-customred text-white",
-                onchange: "this.form.requestSubmit()"
-              }
-          %>
-          <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
-          <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
-        <% end %>
+          <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[180px]", id: "genre-filter-form-pc" do |f| %>
+            <%= f.select :genre,
+                Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+                { include_blank: "すべてのジャンル", selected: params[:genre] },
+                {
+                  class: "w-full px-4 py-2 text-sm border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+            <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+          <% end %>
+        </div>
+      </div>
+
+      <!-- スマホ表示 -->
+      <div class="md:hidden">
+        <div class="flex flex-col gap-2">
+          <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-full", id: "sort-filter-form-mobile" do |f| %>
+            <%= f.select :sort,
+                [['新しい順', 'desc'], ['古い順', 'asc']],
+                { selected: params[:sort] || 'desc' },
+                {
+                  class: "w-full px-2 py-1 text-xs border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+            <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+          <% end %>
+
+          <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-full", id: "emotion-filter-form-mobile" do |f| %>
+            <%= f.select :emotion,
+                Journal.emotions.keys.map { |key| [key.humanize, key] },
+                { include_blank: "すべての感情", selected: params[:emotion] },
+                {
+                  class: "w-full px-2 py-1 text-xs border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
+            <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+          <% end %>
+
+          <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-full", id: "genre-filter-form-mobile" do |f| %>
+            <%= f.select :genre,
+                Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
+                { include_blank: "すべてのジャンル", selected: params[:genre] },
+                {
+                  class: "w-full px-2 py-1 text-xs border rounded-md bg-customred text-white",
+                  onchange: "this.form.requestSubmit()"
+                }
+            %>
+            <%= f.hidden_field :emotion, value: params[:emotion] if params[:emotion].present? %>
+            <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
+          <% end %>
+        </div>
       </div>
     </div>
 

--- a/app/views/journals/timeline.html.erb
+++ b/app/views/journals/timeline.html.erb
@@ -1,22 +1,28 @@
+<!-- ページ全体のコンテナ -->
 <div class="min-h-screen bg-customblue text-black flex flex-col items-center pt-8 pb-8">
-  <div class="bg-white p-6 rounded shadow-md w-full max-w-7xl">
+  <div class="bg-white p-6 rounded shadow-md w-full max-w-7xl mx-auto">
     <!-- ヘッダー部分 -->
-    <div class="flex justify-between items-center mb-6">
-      <div>
-        <h1 class="text-2xl font-bold">タイムライン</h1>
-        <% if user_signed_in? %>
-          <p class="text-sm text-gray-600 mt-1">*フォローボタンを押すと日記を書いたユーザーをフォローできます。</p>
-        <% else %>
-          <p class="text-sm text-gray-600 mt-1">*ログインするとユーザーをフォローして、フォローしたユーザーの日記を見ることができます。</p>
-        <% end %>
+    <div class="flex flex-col md:flex-row justify-center items-center mb-6 gap-4">
+      <div class="w-auto text-center">
+        <div class="flex items-center justify-center">
+          <h1 class="text-lg md:text-2xl font-bold">タイムライン</h1>
+        </div>
+        <p class="text-sm text-gray-600 mt-2 md:mt-1">
+          <% if user_signed_in? %>
+            *フォローボタンを押すと日記を書いたユーザーをフォローできます。
+          <% else %>
+            *ログインするとユーザーをフォローして、フォローしたユーザーの日記を見ることができます。
+          <% end %>
+        </p>
       </div>
-      <div class="flex items-center gap-2">
-        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "sort-filter-form" do |f| %>
+
+      <div class="flex flex-wrap items-center justify-center gap-2 w-full">
+        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[30%] min-w-[100px]", id: "sort-filter-form" do |f| %>
           <%= f.select :sort,
               [['新しい順', 'desc'], ['古い順', 'asc']],
               { selected: params[:sort] || 'desc' },
               {
-                class: "px-4 py-2 border rounded-md bg-customred",
+                class: "w-full px-2 md:px-4 py-1 md:py-2 text-sm md:text-base border rounded-md bg-customred text-white",
                 onchange: "this.form.requestSubmit()"
               }
           %>
@@ -24,12 +30,12 @@
           <%= f.hidden_field :genre, value: params[:genre] if params[:genre].present? %>
         <% end %>
 
-        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "emotion-filter-form" do |f| %>
+        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[30%] min-w-[100px]", id: "emotion-filter-form" do |f| %>
           <%= f.select :emotion,
               Journal.emotions.keys.map { |key| [key.humanize, key] },
               { include_blank: "すべての感情", selected: params[:emotion] },
               {
-                class: "px-4 py-2 border rounded-md bg-customred",
+                class: "w-full px-2 md:px-4 py-1 md:py-2 text-sm md:text-base border rounded-md bg-customred text-white",
                 onchange: "this.form.requestSubmit()"
               }
           %>
@@ -37,12 +43,12 @@
           <%= f.hidden_field :sort, value: params[:sort] if params[:sort].present? %>
         <% end %>
 
-        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "flex items-center space-x-2 text-white", id: "genre-filter-form" do |f| %>
+        <%= form_with url: timeline_journals_path, method: :get, local: true, class: "w-[30%] min-w-[100px]", id: "genre-filter-form" do |f| %>
           <%= f.select :genre,
               Journal.genres.map { |k, v| [t("activerecord.attributes.journal.genre.#{k}"), k] },
               { include_blank: "すべてのジャンル", selected: params[:genre] },
               {
-                class: "px-4 py-2 border rounded-md bg-customred",
+                class: "w-full px-2 md:px-4 py-1 md:py-2 text-sm md:text-base border rounded-md bg-customred text-white",
                 onchange: "this.form.requestSubmit()"
               }
           %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,10 +67,13 @@
   </head>
 
   <body class="flex flex-col min-h-screen">
-    <%= render "shared/header" %>
-    <%= render "devise/shared/flash_messages" %> 
-    <%= yield %>
-    <%= yield(:js) %>
-    <%= render "shared/footer" %>
+    <div class="flex-grow flex flex-col bg-customblue">
+      <%= render "shared/header" %>
+      <%= render "devise/shared/flash_messages" %>
+      <main class="flex-grow flex flex-col">
+        <%= yield %>
+      </main>
+      <%= render "shared/footer" %>
+    </div>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="bg-footer shadow py-2">
+<footer class="bg-footer shadow py-2 mt-auto">
     <div class="container mx-auto px-4">
         <div class="flex flex-col items-center">
             <div class="flex space-x-6 mb-1">

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -53,6 +53,12 @@ ja:
       locked: アカウントはロックされています。
       timeout: セッションがタイムアウトしました。もう一度ログインしてください。
       unauthenticated: ログインもしくはアカウント登録してください。
+    omniauth_callbacks:
+      google_oauth2:
+        success: "Googleログインに成功しました"
+        failure: "Googleログインに失敗しました"
+      failure: "%{kind}認証に失敗しました。理由：%{reason}"
+      success: "%{kind}認証に成功しました。"
     mailer:
       confirmation_instructions:
         subject: メールアドレス確認メール


### PR DESCRIPTION
**概要**
- Spotifyログインの設定を追加（ただし、現状不要のためコメントアウト）。
- タイムラインと一覧ページのレスポンシブデザイン対応。
- ログイン・新規登録ページのレイアウト崩れを修正。

**変更内容**
- `skip_before_action :verify_authenticity_token, only: [:google_oauth2, :spotify]` を追加（ただしコメントアウト中）。
- `google_oauth2` メソッドのエラーハンドリングを強化。
- ログイン・新規登録ページのデザイン修正（`div` のクラス変更、スタイル調整）。
- `journal_card.html.erb` のレイアウト調整（プロフィール画像のリンク化、タグのレスポンシブ対応）。
- `journals/index.html.erb` のレイアウト調整（フィルターのレスポンシブ対応）。

**動作確認方法**
1. ログイン・新規登録ページのデザインが正しく表示されることを確認。
2. タイムラインと一覧ページがスマホでも崩れずに表示されることを確認。
3. Spotifyログインが不要な状態であることを確認（コメントアウトされている）。

**備考**
- Spotifyログインの実装は今後必要になった際に有効化予定。