### PR TITLE
マイページ、他ユーザページ、曲選択ページのレスポンシブデザインと周辺の軽微な修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,10 +7,10 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if @user.persisted?
       sign_in_and_redirect @user, event: :authentication
-      set_flash_message(:notice, :success, scope: [:devise, :omniauth_callbacks, :google_oauth2]) if is_navigational_format?
+      set_flash_message(:notice, :success, scope: [ :devise, :omniauth_callbacks, :google_oauth2 ]) if is_navigational_format?
     else
       Rails.logger.error "OAuth user creation failed: #{@user.errors.full_messages.join(', ')}"
-      set_flash_message(:alert, :failure, scope: [:devise, :omniauth_callbacks, :google_oauth2])
+      set_flash_message(:alert, :failure, scope: [ :devise, :omniauth_callbacks, :google_oauth2 ])
       redirect_to new_user_registration_url
     end
   rescue => e

--- a/app/views/follows/_button_content.html.erb
+++ b/app/views/follows/_button_content.html.erb
@@ -2,14 +2,14 @@
   <% if current_user.following?(user) %>
     <%= button_to unfollow_user_path(user), 
         method: :delete,
-        class: "px-2 py-1 bg-gray-500 text-white rounded-full text-xs hover:bg-gray-600 transform-none" do %>
+        class: "px-2 py-1 bg-gray-500 text-white rounded-full text-xs hover:bg-gray-600 transform-none whitespace-nowrap" do %>
       <i class="fas fa-user-minus mr-1"></i>フォロー中
     <% end %>
   <% else %>
     <%= button_to follow_user_path(user), 
         method: :post,
-        class: "px-2 py-1 bg-blue-500 text-white rounded-full text-xs hover:bg-blue-600 transform-none" do %>
+        class: "px-2 py-1 bg-blue-500 text-white rounded-full text-xs hover:bg-blue-600 transform-none whitespace-nowrap" do %>
       <i class="fas fa-user-plus mr-1"></i>フォロー
     <% end %>
   <% end %>
-<% end %> 
+<% end %>

--- a/app/views/follows/show.html.erb
+++ b/app/views/follows/show.html.erb
@@ -11,35 +11,29 @@
 
     <div class="space-y-4">
       <% @users.each do |user| %>
-        <%= link_to other_user_path(user), class: "block" do %>
-          <div class="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50">
-            <div class="flex items-center gap-4">
-              <!-- アイコン -->
-              <div class="w-12 h-12 rounded-full bg-gray-200 overflow-hidden">
-                <% if user.avatar&.attached? %>
-                  <%= image_tag user.avatar, class: "w-full h-full object-cover" %>
-                <% else %>
-                  <div class="w-full h-full flex items-center justify-center bg-gray-300">
-                    <%= image_tag 'profile_sample.png', class: "w-full h-full object-cover" %>
-                  </div>
-                <% end %>
-              </div>
-              
-              <!-- ユーザー情報 -->
-              <div>
-                <div class="font-bold"><%= user.name %></div>
-                <div class="text-sm text-gray-600">
-                  <%= user.bio.present? ? user.bio.truncate(50) : "自己紹介はまだありません" %>
+        <div class="flex items-center justify-between p-4 border rounded-lg hover:bg-gray-50">
+          <%= link_to other_user_path(user), class: "flex items-center gap-4" do %>
+            <!-- アイコン -->
+            <div class="w-12 h-12 rounded-full bg-gray-200 overflow-hidden">
+              <% if user.avatar&.attached? %>
+                <%= image_tag user.avatar, class: "w-full h-full object-cover" %>
+              <% else %>
+                <div class="w-full h-full flex items-center justify-center bg-gray-300">
+                  <%= image_tag 'profile_sample.png', class: "w-full h-full object-cover" %>
                 </div>
-              </div>
+              <% end %>
             </div>
+            <!-- ユーザー情報 -->
+            <div>
+              <div class="font-bold"><%= user.name %></div>
+            </div>
+          <% end %>
 
-            <!-- フォローボタン（自分以外のユーザーの場合） -->
-            <% if user_signed_in? && current_user != user %>
-              <%= render 'follows/button', user: user %>
-            <% end %>
-          </div>
-        <% end %>
+          <!-- フォローボタン（自分以外のユーザーの場合） -->
+          <% if user_signed_in? && current_user != user %>
+            <%= render 'follows/button', user: user %>
+          <% end %>
+        </div>
       <% end %>
     </div>
 

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -86,7 +86,7 @@
     </div>
 
     <!-- Mobile View -->
-    <div class="flex sm:hidden gap-2 h-12">
+    <div class="flex sm:hidden gap-2 h-12 items-center justify-center">
       <%= link_to '詳細', journal_path(journal), data: { turbo: false },
           class: "w-20 h-12 flex items-center justify-center bg-gray-500 text-white text-sm rounded hover:bg-gray-600" %>
       <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -68,8 +68,9 @@
   </div>
 
   <!-- アクションボタン -->
-  <div class="flex gap-3">
-    <% if user_signed_in? && journal.user == current_user %>
+  <% if user_signed_in? && journal.user == current_user %>
+    <!-- PC View -->
+    <div class="hidden sm:flex gap-3">
       <%= link_to '詳細', journal_path(journal), data: { turbo: false },
           class: "flex-1 text-center py-3 px-6 bg-gray-500 text-white text-base rounded hover:bg-gray-600" %>
       <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },
@@ -82,12 +83,27 @@
           削除
         </button>
       <% end %>
-    <% else %>
+    </div>
+
+    <!-- Mobile View -->
+    <div class="flex sm:hidden gap-2 h-12">
+      <%= link_to '詳細', journal_path(journal), data: { turbo: false },
+          class: "w-20 h-12 flex items-center justify-center bg-gray-500 text-white text-sm rounded hover:bg-gray-600" %>
+      <%= link_to "編集", edit_journal_path(journal), data: { turbo: false },
+          class: "w-20 h-12 flex items-center justify-center bg-yellow-500 text-white text-sm rounded hover:bg-yellow-600" %>
+      <%= button_to "削除",
+          journal_path(journal),
+          method: :delete,
+          data: { turbo: false, confirm: "本当に削除しますか？" },
+          class: "w-20 h-12 flex items-center justify-center bg-red-500 text-white text-sm rounded hover:bg-red-600" %>
+    </div>
+  <% else %>
+    <div class="flex gap-3">
       <%= link_to '詳細', journal_path(journal), data: { turbo: false },
           class: "flex-1 text-center py-3 px-6 bg-gray-500 text-white text-base rounded hover:bg-gray-600" %>
       <% if user_signed_in? %>
         <%= render 'journals/favorite_button', journal: journal %>
       <% end %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -5,8 +5,8 @@
       <%= journal.title %>
     </h3>
     <div class="flex items-center gap-4 mt-2">
-      <span class="text-base">by <%= link_to journal.user.name, other_user_path(journal.user) %></span>
-      <%= link_to other_user_path(journal.user) do %>
+      <span class="text-base whitespace-nowrap">by <%= link_to journal.user.name, other_user_path(journal.user), data: { turbo: false } %></span>
+      <%= link_to other_user_path(journal.user), data: { turbo: false } do %>
         <%= image_tag journal.user.avatar.presence || 'profile_sample.png',
             class: "h-12 w-12 rounded-full object-cover mr-4",
             alt: "プロフィール画像" %>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -22,7 +22,7 @@
           <% end %>
 
           <div class="flex flex-col justify-center items-center mt-4 sm:mt-6 mb-4 sm:mb-6 mx-auto">
-            <h1 class="text-xl sm:text-3xl font-bold text-gray-800 text-center">ユーザープロフィール編集</h1>
+            <h1 class="text-xl sm:text-3xl font-bold text-gray-800 text-center">プロフィール編集</h1>
           </div>
 
           <%# 名前 %>

--- a/app/views/mypages/edit.html.erb
+++ b/app/views/mypages/edit.html.erb
@@ -1,57 +1,62 @@
 <div class="bg-customblue min-h-screen overflow-auto">
-  <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+  <div class="flex flex-col justify-center items-center mt-4 sm:mt-8 mb-4 sm:mb-8 mx-4 md:mx-24 lg:mx-72">
+    <h1 class="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
       <% content_for(:title, 'プロフィール編集') %>
     </h1>
   </div>
 
-  <div class="h-max m-5 p-10 flex flex-col">
+  <div class="mx-4 sm:mx-5 p-4 sm:p-10">
     <div class="flex flex-col justify-center items-center">
-      <div class="bg-white w-[600px] p-8 rounded-lg shadow-sm">
+      <div class="bg-white w-full sm:w-[600px] p-4 sm:p-8 rounded-lg shadow-sm">
         <%= form_with(model: @profile_form, url: mypage_path, local: true, data: {turbo: false}, method: :patch, multipart: true) do |f| %>
           <%# エラーメッセージ %>
           <% if @user.errors.any? || @profile_form.errors.any? %>
-            <div class="bg-red-50 border border-red-200 text-red-600 px-4 py-3 rounded mb-6">
+            <div class="bg-red-50 border border-red-200 text-red-600 px-3 sm:px-4 py-2 sm:py-3 rounded mb-4 sm:mb-6">
               <% @user.errors.full_messages.each do |error| %>
-                <p class="text-sm"><%= error %></p>
+                <p class="text-xs sm:text-sm"><%= error %></p>
               <% end %>
               <% @profile_form.errors.full_messages.each do |error| %>
-                <p class="text-sm"><%= error %></p>
+                <p class="text-xs sm:text-sm"><%= error %></p>
               <% end %>
             </div>
           <% end %>
 
-          <div class="flex flex-col justify-center items-center mt-6 mb-6 mx-auto">
-            <h1 class="text-3xl font-bold text-gray-800 text-center">ユーザープロフィール編集</h1>
+          <div class="flex flex-col justify-center items-center mt-4 sm:mt-6 mb-4 sm:mb-6 mx-auto">
+            <h1 class="text-xl sm:text-3xl font-bold text-gray-800 text-center">ユーザープロフィール編集</h1>
           </div>
 
           <%# 名前 %>
-          <div class="mb-6">
-            <%= f.label :name, t("activerecord.attributes.profile.name"), class: "block text-lg font-medium text-gray-800 mb-3" %>
-            <%= f.text_field :name, value: @user.name, placeholder: t("activerecord.attributes.profile.name"), class: "w-full px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary dark-mode-text" %>
+          <div class="mb-4 sm:mb-6">
+            <%= f.label :name, t("activerecord.attributes.profile.name"), class: "block text-base sm:text-lg font-medium text-primary mb-2 sm:mb-3" %>
+            <%= f.text_field :name, value: @user.name, placeholder: t("activerecord.attributes.profile.name"), 
+                class: "w-full px-3 sm:px-4 py-2 text-sm sm:text-base border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary dark-mode-text" %>
           </div>
 
           <%# アバター画像 %>
-          <div class="mb-6">
-            <%= f.label :avatar, t("activerecord.attributes.profile.avatar"), class: "block text-lg font-medium text-primary mb-3" %>
-            <%= f.file_field :avatar, class: "w-full px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary" %>
+          <div class="mb-4 sm:mb-6">
+            <%= f.label :avatar, t("activerecord.attributes.profile.avatar"), class: "block text-base sm:text-lg font-medium text-primary mb-2 sm:mb-3" %>
+            <%= f.file_field :avatar, 
+                class: "w-full px-3 sm:px-4 py-2 text-sm sm:text-base border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary" %>
           </div>
 
           <%# 自己紹介 %>
-      <div class="mb-6">
-        <%= f.label :bio, t("activerecord.attributes.profile.bio"), class: "block text-lg font-medium text-primary mb-3" %>
-        <%= f.text_area :bio, value: @user.bio, placeholder: t("activerecord.attributes.profile.bio"), class: "w-full px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary h-32 dark-mode-text" %>
-      </div>
+          <div class="mb-4 sm:mb-6">
+            <%= f.label :bio, t("activerecord.attributes.profile.bio"), class: "block text-base sm:text-lg font-medium text-primary mb-2 sm:mb-3" %>
+            <%= f.text_area :bio, value: @user.bio, placeholder: t("activerecord.attributes.profile.bio"), 
+                class: "w-full px-3 sm:px-4 py-2 text-sm sm:text-base border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary h-24 sm:h-32 dark-mode-text" %>
+          </div>
 
           <%# SNSリンク %>
-          <div class="mb-6">
-            <%= f.label :x_link, t("activerecord.attributes.profile.x_link"), class: "block text-lg font-medium text-primary mb-3" %>
-            <%= f.text_field :x_link, value: @user.x_link, placeholder: t("activerecord.attributes.profile.x_link"), class: "w-full px-4 py-2 border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary dark-mode-text" %>
+          <div class="mb-4 sm:mb-6">
+            <%= f.label :x_link, t("activerecord.attributes.profile.x_link"), class: "block text-base sm:text-lg font-medium text-primary mb-2 sm:mb-3" %>
+            <%= f.text_field :x_link, value: @user.x_link, placeholder: t("activerecord.attributes.profile.x_link"), 
+                class: "w-full px-3 sm:px-4 py-2 text-sm sm:text-base border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary dark-mode-text" %>
           </div>
 
           <%# 更新ボタン %>
-          <div class="flex flex-col items-center gap-4">
-            <%= f.submit t("activerecord.attributes.profile.update"), class: "btn btn-accent text-white bg-accent hover:bg-accent-dark w-full max-w-md text-lg font-bold" %>
+          <div class="flex flex-col items-center gap-3 sm:gap-4">
+            <%= f.submit t("activerecord.attributes.profile.update"), 
+                class: "btn btn-accent text-white bg-accent hover:bg-accent-dark w-full max-w-md text-base sm:text-lg font-bold py-2 sm:py-3" %>
           </div>
         <% end %>
       </div>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,44 +1,46 @@
 <div class="bg-customblue min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+    <h1 class="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
       <% content_for(:title, 'マイページ') %>
     </h1>
   </div>
 
   <%# プロフィールセクション %>
-  <div class=" mx-5 p-10">
+  <div class="mx-4 sm:mx-5 p-4 sm:p-10">
     <div class="flex flex-col justify-center items-center">
-      <div class="bg-white w-[800px] p-8 rounded-lg shadow-sm">
+      <div class="bg-white w-full sm:w-[800px] p-4 sm:p-8 rounded-lg shadow-sm">
         <%# プロフィール上部：アバターと名前とXアイコン %>
-        <div class="flex space-x-8 items-center mb-8 justify-center">
-          <div class="text-center">
+        <div class="flex flex-col sm:flex sm:flex-row sm:space-x-8 items-center mb-6 sm:mb-8 justify-center">
+          <div class="text-center mb-4 sm:mb-0">
             <% if current_user.avatar.attached? %>
-              <%= image_tag current_user.avatar, class: 'w-24 h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
+              <%= image_tag current_user.avatar, class: 'w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
             <% else %>
-              <%= image_tag 'profile_sample.png', class: 'w-24 h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
+              <%= image_tag 'profile_sample.png', class: 'w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
             <% end %>
           </div>
           <div class="text-accent">
-            <div class="flex items-center space-x-8">
-              <p class="text-4xl font-bold"><%= current_user.name %></p>
-              <% if current_user.x_link.present? %>
-                <%= link_to current_user.x_link, target: "_blank", rel: "noopener noreferrer", data: { turbo: false } do %>
-                  <i class="fa-brands fa-x-twitter text-gray-400 text-4xl hover:text-gray-600"></i>
+            <div class="flex flex-col sm:flex sm:flex-row sm:items-center sm:space-x-8">
+              <p class="text-2xl sm:text-4xl font-bold text-center mb-2 sm:mb-0"><%= current_user.name %></p>
+              <div class="flex items-center justify-center space-x-4 sm:space-x-8">
+                <% if current_user.x_link.present? %>
+                  <%= link_to current_user.x_link, target: "_blank", rel: "noopener noreferrer", data: { turbo: false } do %>
+                    <i class="fa-brands fa-x-twitter text-gray-400 text-3xl sm:text-4xl hover:text-gray-600"></i>
+                  <% end %>
+                <% else %>
+                  <%= link_to mypage_path(show_notice: true), class: "cursor-not-allowed" do %>
+                    <i class="fa-brands fa-x-twitter text-gray-400 text-3xl sm:text-4xl"></i>
+                  <% end %>
                 <% end %>
-              <% else %>
-                <%= link_to mypage_path(show_notice: true), class: "cursor-not-allowed" do %>
-                  <i class="fa-brands fa-x-twitter text-gray-400 text-4xl"></i>
-                <% end %>
-              <% end %>
-              <!-- フォロー/フォロワー -->
-              <div id="follow-stats" class="flex items-center space-x-4">
-                <%= render 'follows/stats', user: current_user %>
+                <!-- フォロー/フォロワー -->
+                <div id="follow-stats" class="flex items-center space-x-4">
+                  <%= render 'follows/stats', user: current_user %>
+                </div>
               </div>
             </div>
           </div>
         </div>
         <%# プロフィール文 %>
-        <div class="bg-gray-200 rounded-lg text-base mb-8 p-6 text-gray-700">
+        <div class="bg-gray-200 rounded-lg text-sm sm:text-base mb-6 sm:mb-8 p-4 sm:p-6 text-gray-700">
           <% if @user.bio.present? %>
             <p class="text-center text-gray-400"><%= @user.bio %></p>
           <% else %>
@@ -48,22 +50,22 @@
         <%# プロフィール編集ボタン %>
         <div class="flex justify-center">
           <%= link_to edit_mypage_path, 
-              class: "flex items-center space-x-2 px-6 py-3 bg-gray-50 hover:bg-gray-100 rounded-lg text-primary transition duration-200" do %>
-            <span class="material-symbols-outlined text-base">edit</span>
-            <span class="text-base">プロフィール編集</span>
+              class: "flex items-center space-x-2 px-4 sm:px-6 py-2 sm:py-3 bg-gray-50 hover:bg-gray-100 rounded-lg text-primary transition duration-200" do %>
+            <span class="material-symbols-outlined text-sm sm:text-base">edit</span>
+            <span class="text-sm sm:text-base">プロフィール編集</span>
           <% end %>
         </div>
       </div>
     </div>
   </div>
 
-  <%# 投稿セクション - 上部にマージンを追加 %>
-  <div class="mx-5 mt-8 p-10">
-    <div class="bg-gray-200 p-6 rounded-lg shadow-sm">
+  <%# 投稿セクション %>
+  <div class="mx-4 sm:mx-5 mt-4 sm:mt-8 p-4 sm:p-10">
+    <div class="bg-gray-200 p-4 sm:p-6 rounded-lg shadow-sm">
       <%# タブナビゲーション %>
-      <div class="border-b border-gray-200 mb-6">
-        <nav class="flex space-x-8" aria-label="Tabs">
-          <ul class="tab-list list-unstyled">
+      <div class="border-b border-gray-200 mb-4 sm:mb-6">
+        <nav class="flex space-x-4 sm:space-x-8" aria-label="Tabs">
+          <ul class="tab-list list-unstyled text-sm sm:text-base">
             <li class="tab <%= 'tab-active' if session[:mypage_tab] != 'liked_posts' %>">
               <%= link_to "自分の投稿", mypage_path(tab: "my_posts"), data: { turbo_frame: "posts_content" } %>
             </li>
@@ -80,11 +82,12 @@
             journals: @journals,
             liked_journals: @liked_journals %>
       <% end %>
-         <!-- 新規作成ボタン -->
-    <div class="mt-6">
-      <%= link_to "新しい日記を作成", new_journal_path, 
-          class: "w-full block text-center py-3 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors" %>
-    </div>
+
+      <!-- 新規作成ボタン -->
+      <div class="mt-4 sm:mt-6">
+        <%= link_to "新しい日記を作成", new_journal_path, 
+            class: "w-full block text-center py-2 sm:py-3 text-sm sm:text-base bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors" %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/other_users/show.html.erb
+++ b/app/views/other_users/show.html.erb
@@ -1,50 +1,51 @@
 <div class="bg-customblue min-h-screen overflow-auto">
   <div class="flex flex-col justify-center items-center mt-8 mb-8 mx-4 md:mx-24 lg:mx-72">
-    <h1 class="text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
+    <h1 class="text-2xl sm:text-3xl md:text-3xl lg:text-4xl font-bold text-accent text-center">
       <% content_for(:title, "#{@user.name}さんのページ") %>
     </h1>
   </div>
 
   <%# プロフィールセクション %>
-  <div class=" mx-5 p-10">
+  <div class="mx-4 sm:mx-5 p-4 sm:p-10">
     <div class="flex flex-col justify-center items-center">
-      <div class="bg-white w-[800px] p-8 rounded-lg shadow-sm">
+      <div class="bg-white w-full sm:w-[800px] p-4 sm:p-8 rounded-lg shadow-sm">
         <%# プロフィール上部：アバターと名前とXアイコン %>
-        <div class="flex space-x-8 items-center mb-8 justify-center">
-          <div class="text-center">
+        <div class="flex flex-col sm:flex sm:flex-row sm:space-x-8 items-center mb-6 sm:mb-8 justify-center">
+          <div class="text-center mb-4 sm:mb-0">
             <% if @user.avatar&.attached? %>
-              <%= image_tag @user.avatar, class: 'w-24 h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
+              <%= image_tag @user.avatar, class: 'w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
             <% else %>
-              <%= image_tag 'profile_sample.png', class: 'w-24 h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
+              <%= image_tag 'profile_sample.png', class: 'w-20 h-20 sm:w-24 sm:h-24 rounded-full object-cover border-2 border-primary shadow-sm' %>
             <% end %>
           </div>
           <div class="text-accent">
-            <div class="flex items-center space-x-8">
-              <p class="text-4xl font-bold"><%= @user.name %></p>
-              <% if @user.x_link.present? %>
-                <%= link_to x_redirect_other_user_path(@user), target: "_blank", rel: "noopener noreferrer", data: { turbo: false } do %>
-                  <i class="fa-brands fa-x-twitter text-gray-400 text-4xl hover:text-gray-600"></i>
+            <div class="flex flex-col sm:flex sm:flex-row sm:items-center sm:space-x-8">
+              <p class="text-2xl sm:text-4xl font-bold text-center mb-2 sm:mb-0"><%= @user.name %></p>
+              <div class="flex flex-wrap items-center justify-center gap-2 sm:gap-4">
+                <% if @user.x_link.present? %>
+                  <%= link_to x_redirect_other_user_path(@user), target: "_blank", rel: "noopener noreferrer", data: { turbo: false } do %>
+                    <i class="fa-brands fa-x-twitter text-gray-400 text-3xl sm:text-4xl hover:text-gray-600"></i>
+                  <% end %>
+                <% else %>
+                  <%= link_to other_user_path(@user, show_notice: true), class: "cursor-not-allowed" do %>
+                    <i class="fa-brands fa-x-twitter text-gray-400 text-3xl sm:text-4xl"></i>
+                  <% end %>
                 <% end %>
-              <% else %>
-                <%= link_to other_user_path(@user, show_notice: true), class: "cursor-not-allowed" do %>
-                  <i class="fa-brands fa-x-twitter text-gray-400 text-4xl"></i>
+
+                <!-- フォロー/フォロワー -->
+                <div id="follow-stats" class="flex items-center">
+                  <%= render 'follows/stats', user: @user %>
+                </div>
+                <!-- フォローボタン -->
+                <% if user_signed_in? && current_user != @user %>
+                  <%= render 'follows/button', user: @user %>
                 <% end %>
-              <% end %>
-
-
-              <!-- フォロー/フォロワー -->
-              <div id="follow-stats" class="flex items-center space-x-4">
-                <%= render 'follows/stats', user: @user %>
               </div>
-              <!-- フォローボタン -->
-              <% if user_signed_in? && current_user != @user %>
-                <%= render 'follows/button', user: @user %>
-              <% end %>
             </div>
           </div>
         </div>
         <%# プロフィール文 %>
-        <div class="bg-gray-200 rounded-lg text-base mb-8 p-6 text-gray-700">
+        <div class="bg-gray-200 rounded-lg text-sm sm:text-base mb-6 sm:mb-8 p-4 sm:p-6 text-gray-700">
           <% if @user.bio.present? %>
             <p class="text-center text-gray-700"><%= @user.bio %></p>
           <% else %>
@@ -55,9 +56,9 @@
     </div>
   </div>
 
-  <%# 投稿セクション - 上部にマージンを追加 %>
-  <div class="mx-5 mt-8 p-10">
-    <div class="bg-gray-200 p-6 rounded-lg shadow-sm">
+  <%# 投稿セクション %>
+  <div class="mx-4 sm:mx-5 p-4 sm:p-10">
+    <div class="bg-gray-200 p-4 sm:p-6 rounded-lg shadow-sm">
       <%# タブナビゲーション %>
       <div class="border-b border-gray-200 mb-6">
         <nav class="flex space-x-8" aria-label="Tabs">

--- a/app/views/spotify/results.html.erb
+++ b/app/views/spotify/results.html.erb
@@ -36,8 +36,8 @@
                       loading="lazy"
                       class="w-full rounded-lg">
               </iframe>
-
-            <%= render 'shared/spotify_fallback', track_id: track[:spotify_track_id] %>
+            </div>
+            
 
             <!-- 曲情報 -->
             <div class="space-y-3">


### PR DESCRIPTION
# 概要
- マイページのレスポンシブ対応  
- 他ユーザーページのレスポンシブ対応  
- 曲検索結果ページのレイアウト修正  
- その他の改善点  

# 変更内容

## 1. マイページ（mypages/show.html.erb）
- **プロフィール画像サイズの調整**  
  - モバイル: `w-20 h-20`  
  - デスクトップ: `sm:w-24 sm:h-24`  
- **ユーザー名とXアイコンのレイアウト**  
  - モバイル: 縦並び配置  
  - デスクトップ: `sm:flex-row` で横並び  

## 2. 他ユーザーページ（other_users/show.html.erb）
- **マイページと同じレスポンシブ対応**  
- **フォロー/フォロワー部分のレイアウト改善**  
  - `flex-wrap` でモバイル表示時の折り返し対応  
  - `gap-2 sm:gap-4` で適切な間隔確保  

## 3. プロフィール編集ページ（mypages/edit.html.erb）
- **フォーム要素の幅と余白を調整**  
- **エラーメッセージのフォントサイズ調整**  
  - モバイル: `text-xs`  
  - デスクトップ: `sm:text-sm`  

## 4. その他の改善点
- `data: { turbo: false }` の追加  
- ユーザー名クリック時の遷移を改善  
- アバター画像クリック時の遷移を改善  
- フォローボタンに `whitespace-nowrap` を追加  
- カード全体のリンクを個別要素に分割（フォロー/フォロワーページ）  

---