### PR TITLE
検索が機能しないアーティストがあったので修正しました

### DIFF
--- a/app/controllers/concerns/spotify/spotify_searchable.rb
+++ b/app/controllers/concerns/spotify/spotify_searchable.rb
@@ -163,7 +163,7 @@ module Spotify::SpotifySearchable
     @total_pages = (@total_count.to_f / @per_page).ceil
     @current_page = page
     @offset_value = (page - 1) * @per_page
-    
+
     @tracks = Kaminari.paginate_array(
       results["tracks"]["items"].map do |track|
         {
@@ -175,7 +175,7 @@ module Spotify::SpotifySearchable
       end,
       total_count: @total_count
     ).page(@current_page).per(@per_page)
-    
+
     Rails.logger.info "📝 Processed #{@tracks.size} tracks"
     @tracks
   end


### PR DESCRIPTION
## 概要
Spotify検索機能のエラーハンドリングとページネーション機能の改善  
nilエラーの解消とコードの可読性向上

## 変更内容

###  修正
#### エラーハンドリング:
- `process_search_results`メソッドでのnilチェックを強化
- 安全なメソッドチェーン（`&.`、`dig`）の導入
- エラー時の二重レンダリング防止

#### ページネーション:
- Kaminariの設定を一箇所に集約
- ページネーション関連変数の初期化を整理

###  リファクタリング

#### コード構造の改善:
- 条件分岐のシンプル化
- 不要なネストの削除
- ログ出力の追加

##  技術的なポイント

### 1. 早期リターンによる条件分岐の簡素化
```ruby
return [] unless results && results["tracks"]
```

### 2. ページネーション変数の集約
```ruby
@total_count = results["tracks"]["total"]
@total_pages = (@total_count.to_f / @per_page).ceil
@current_page = page
@offset_value = (page - 1) * @per_page
```

### 3. nilセーフなメソッドチェーン
```ruby
artist_name: track["artists"]&.first&.dig("name") || "Unknown Artist"
```

### 4. Kaminariの効率的な利用
```ruby
Kaminari.paginate_array(tracks, total_count: @total_count)
        .page(@current_page).per(@per_page)
```

### 5. エラーハンドリングの改善
```ruby
render partial: "spotify/search" and return
```

## 動作確認方法

### 基本的な検索機能
- [ ] アーティスト名で検索し、正常に結果が表示される
- [ ] 検索結果が正しくページネーションされる

### エラーハンドリング
- [ ] アーティスト情報がない場合も"Unknown Artist"と表示
- [ ] アルバム画像がない場合もエラーにならない

### ページネーション
- [ ] 複数ページの結果で正しく遷移できる
- [ ] ページ情報（全件数、現在のページ）が正しく表示される
