### PR TITLE
アプリの使い方ページを削除

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -20,9 +20,6 @@
   <% else %>
      <div class="absolute top-[60%] left-1/2 transform -translate-x-1/2 sm:top-[25%] sm:left-1/2 sm:transform sm:-translate-x-1/2 sm:-translate-y-1/2 lg:top-[75%] lg:left-[15rem]">
       <div class="bg-customblue text-white font-bold py-8 px-4 rounded-full w-80 text-center text-3xl mt-4">
-        <%= link_to "アプリの使い方".html_safe, app_explanation_path %>
-      </div>
-      <div class="bg-customblue text-white font-bold py-8 px-4 rounded-full w-80 text-center text-3xl mt-4">
         <%= link_to "タイムライン".html_safe, timeline_journals_path %>
       </div>
     </div>


### PR DESCRIPTION
## 概要
- 現状、アプリの使い方ページは不要と判断したので 、リンクを削除しました

## 変更内容
- **削除**:  
```
      <div class="bg-customblue text-white font-bold py-8 px-4 rounded-full w-80 text-center text-3xl mt-4">
        <%= link_to "アプリの使い方".html_safe, app_explanation_path %>
      </div>
```
を削除