### PR TITLE
productionの環境をAsia/Tokyoに　　過去の日記一覧ページの不要な記載の削除

### DIFF
--- a/app/views/journals/_journal_card.html.erb
+++ b/app/views/journals/_journal_card.html.erb
@@ -62,7 +62,7 @@
         <%= t("activerecord.attributes.journal.genre.#{journal.genre}") %>
       </div>
       <div class="inline-flex px-3 md:px-4 py-1 md:py-2 bg-green-500 text-white rounded-full text-sm md:text-sm">
-        <%= journal.created_at.strftime("%m/%d %H:%M") %>
+        <%= journal.created_at.in_time_zone('Asia/Tokyo').strftime("%m/%d %H:%M") %>
       </div>
     <% end %>
   </div>

--- a/app/views/journals/index.html.erb
+++ b/app/views/journals/index.html.erb
@@ -4,7 +4,6 @@
     <div class="flex flex-col md:flex-row justify-between items-center mb-6">
       <div class="w-full md:w-auto text-center md:text-left">
         <h1 class="text-lg md:text-2xl font-bold"><%= "#{current_user.name}'s Journal" %></h1>
-        <p class="text-sm text-gray-600 mt-2 md:mt-1">*ジャンルは選択した曲から自動的に設定されます。</p>
       </div>
 
       <!-- PC表示のフィルター -->

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -129,6 +129,6 @@ Rails.application.configure do
     }
   }
 
-  config.time_zone = "UTC"
+  config.time_zone = "Asia/Tokyo"
   config.active_record.default_timezone = :utc
 end


### PR DESCRIPTION
## 概要
- タイムラインページのTagの作成時間がUTCになっていたので、下記コードをRenderのshellのRails cに打ち込むことで修正しました
```
Journal.find_each do |journal|
  puts "Updating journal ID: #{journal.id}"
  journal.update_columns(
    created_at: journal.created_at.in_time_zone('Asia/Tokyo'),
    updated_at: journal.updated_at.in_time_zone('Asia/Tokyo')
  )
end
```
- 過去の日記一覧ページに挙動と矛盾する記載があったので削除しました

## スクリーンショット
- 日本時間対応
![image](https://github.com/user-attachments/assets/89fb39e5-835d-4481-8cd3-5d09f182da1a)