### PR TITLE
N + 1問題の解消（favoriteとavatarで発生していたので解消）

### DIFF
--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -14,25 +14,25 @@ class JournalsController < ApplicationController
     # ログインユーザーの日記を取得
     @journals = current_user.journals
                             .includes(:favorites, user: { avatar_attachment: :blob })
-  
+
     # 感情でフィルタリング
     @journals = @journals.where(emotion: params[:emotion]) if params[:emotion].present?
-  
+
     # ジャンルでフィルタリング
     @journals = @journals.where(genre: params[:genre]) if params[:genre].present?
-  
+
     # 作成日時で並び替えとページネーション
     sort_direction = params[:sort] == "asc" ? :asc : :desc
     @journals = @journals.order(created_at: sort_direction).page(params[:page]).per(6)
-  
+
     # N+1問題を解消しながら、お気に入り数を取得
     @favorite_counts = @journals.each_with_object({}) do |journal, hash|
       hash[journal.id] = journal.favorites.size
     end
-  
+
     # ユーザーがお気に入りしたジャーナルを取得
     favorite_journal_ids = Favorite.where(journal_id: @journals.map(&:id), user_id: current_user.id).pluck(:journal_id)
-    @user_favorites = @journals.map { |journal| [journal.id, favorite_journal_ids.include?(journal.id)] }.to_h if current_user
+    @user_favorites = @journals.map { |journal| [ journal.id, favorite_journal_ids.include?(journal.id) ] }.to_h if current_user
   end
 
   # 公開された日記のタイムラインを表示

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -13,22 +13,32 @@ class JournalsController < ApplicationController
   def index
     # ログインユーザーの日記を取得
     @journals = current_user.journals
-
+                            .includes(:favorites, user: { avatar_attachment: :blob })
+  
     # 感情でフィルタリング
     @journals = @journals.where(emotion: params[:emotion]) if params[:emotion].present?
-
+  
     # ジャンルでフィルタリング
     @journals = @journals.where(genre: params[:genre]) if params[:genre].present?
-
+  
     # 作成日時で並び替えとページネーション
     sort_direction = params[:sort] == "asc" ? :asc : :desc
     @journals = @journals.order(created_at: sort_direction).page(params[:page]).per(6)
+  
+    # N+1問題を解消しながら、お気に入り数を取得
+    @favorite_counts = @journals.each_with_object({}) do |journal, hash|
+      hash[journal.id] = journal.favorites.size
+    end
+  
+    # ユーザーがお気に入りしたジャーナルを取得
+    favorite_journal_ids = Favorite.where(journal_id: @journals.map(&:id), user_id: current_user.id).pluck(:journal_id)
+    @user_favorites = @journals.map { |journal| [journal.id, favorite_journal_ids.include?(journal.id)] }.to_h if current_user
   end
 
   # 公開された日記のタイムラインを表示
   def timeline
     # 公開された日記のみを取得
-    base_query = Journal.where(public: true)
+    base_query = Journal.where(public: true) .includes(:favorites, user: { avatar_attachment: :blob })
 
     if user_signed_in?
       following_user_ids = current_user.following.pluck(:id)

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -42,8 +42,8 @@ class Journal < ApplicationRecord
   scope :by_genre, ->(genre) { where(genre: genre) if genre.present? }
 
   def favorited_by?(user)
-    return false if user.nil?  # userがnilならfalseを返す
-    favorites.exists?(user_id: user.id)
+    @user_favorites ||= favorites.pluck(:user_id)
+    @user_favorites.include?(user.id)
   end
 
   def genre_display_name

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -42,7 +42,7 @@ class Journal < ApplicationRecord
   scope :by_genre, ->(genre) { where(genre: genre) if genre.present? }
 
   def favorited_by?(user)
-    return false if user.nil? 
+    return false if user.nil?
     @user_favorites ||= favorites.pluck(:user_id)
     @user_favorites.include?(user.id)
   end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -42,6 +42,7 @@ class Journal < ApplicationRecord
   scope :by_genre, ->(genre) { where(genre: genre) if genre.present? }
 
   def favorited_by?(user)
+    return false if user.nil? 
     @user_favorites ||= favorites.pluck(:user_id)
     @user_favorites.include?(user.id)
   end


### PR DESCRIPTION
### 概要
N+1問題の解消と、データ取得の最適化を行いました。

### 変更内容
1. **N+1問題の解消**
   - `index` アクションで `@journals` に `includes(:favorites, user: { avatar_attachment: :blob })` を追加。
   - `timeline` アクションでも同様に `includes(:favorites, user: { avatar_attachment: :blob })` を適用。
   - favorited_by? メソッドに user.nil? のチェックを追加し、nil の場合 false を返すよう修正。

2. **お気に入り数の取得の最適化**
   - `@favorite_counts` を `@journals.each_with_object({})` で生成するよう変更。

3. **ユーザーがお気に入りしたジャーナルの取得の最適化**
   - `Favorite.where(journal_id: @journals.map(&:id), user_id: current_user.id).pluck(:journal_id)` を使用して、まとめて取得するよう変更。
   - `@user_favorites` を `@journals.map` でハッシュとして格納。

4. **`Journal#favorited_by?` の最適化**
   - `favorites.exists?(user_id: user.id)` を `@user_favorites ||= favorites.pluck(:user_id)` に変更し、キャッシュを活用。

### 動作確認方法
- ログインユーザーが自身の日記一覧 (`/journals`) を閲覧できること。
- `timeline` ページ (`/journals/timeline`) にアクセスし、公開された日記が表示されること。
- お気に入りボタンの表示が正しく更新されること。
